### PR TITLE
Updates to snow thermal conductivity model

### DIFF
--- a/src/pks/surface_balance/constitutive_relations/SEB/seb_physics_defs.hh
+++ b/src/pks/surface_balance/constitutive_relations/SEB/seb_physics_defs.hh
@@ -119,6 +119,10 @@ struct ModelParams {
   double evap_transition_width;
   double gravity;
 
+  // snow thermal conductivity parameters
+  double snoK;
+  double snoKX;
+
   ModelParams() :
       density_air(1.275),       // [kg/m^3]
       density_freshsnow(100.),  // [kg/m^3]
@@ -132,7 +136,9 @@ struct ModelParams {
       stephB(0.00000005670373), // Stephan-Boltzmann constant ------- [W/m^2 K^4]
       Apa(101.325),             // atmospheric pressure ------------- [kPa]
       evap_transition_width(100.), // transition on evaporation from surface to evaporation from subsurface [m]
-      gravity(9.807) {}         // gravity [kg m / s^2]
+      gravity(9.807),           // gravity [kg m / s^2]
+      snoK(0.029),              // thermal conductivity of snow at rho=100kg/m^3  [W/m K]
+      snoKX(2) {}               // exponent used to describe thermal conductivity as a function of snow density [-]
 };
 
 

--- a/src/pks/surface_balance/constitutive_relations/SEB/seb_physics_funcs.cc
+++ b/src/pks/surface_balance/constitutive_relations/SEB/seb_physics_funcs.cc
@@ -120,11 +120,11 @@ void UpdateEnergyBalance(const SEB& seb, const ThermoProperties& vp_surf, Energy
 
   // Calculate heat conducted to ground, if snow
   if (seb.in.snow_old.ht > 0.) {
-    double Ks = 2.9e-6 * std::pow(seb.in.snow_old.density,2);
+    double Ks = seb.params.snoK * 1e-4 * std::pow(seb.in.snow_old.density,seb.params.snoKX);
     double snow_hoar_density = 0;
     if(seb.in.snow_old.density>150){
       snow_hoar_density = 1/((0.90/seb.in.snow_old.density)+(0.10/150));
-      Ks = 2.9e-6 * std::pow(snow_hoar_density,2);
+      Ks = seb.params.snoK * 1e-4 * std::pow(snow_hoar_density,seb.params.snoKX);
     }
     eb.fQc = Ks * (vp_surf.temp - seb.in.vp_ground.temp) / seb.in.snow_old.ht;
   }

--- a/src/pks/surface_balance/explicit/surface_balance_explicit.cc
+++ b/src/pks/surface_balance/explicit/surface_balance_explicit.cc
@@ -58,6 +58,10 @@ SurfaceBalanceExplicit::SurfaceBalanceExplicit(
   // min wind speed
   min_wind_speed_ = plist_->get<double>("minimum wind speed", 1.0);
 
+  // snow thermal conductivity model parameters
+  snow_lambda_fresh_ = plist_->get<double>("thermal conductivity of fresh snow [W/m K]", 0.029);
+  snow_lambda_exponent_ = plist_->get<double>("thermal conductivity aging exponent for snow", 2.0);
+
   // transition snow depth
   snow_ground_trans_ = plist_->get<double>("snow-ground transitional depth", 0.02);
   min_snow_trans_ = plist_->get<double>("minimum snow transitional depth", 1.e-8);
@@ -338,6 +342,10 @@ SurfaceBalanceExplicit::advance(double dt) {
 
       seb.in.vp_snow.temp = 273.15;
 
+      // -- snow thermal conductivity parameters
+      seb.params.snoK = snow_lambda_fresh_;
+      seb.params.snoKX = snow_lambda_exponent_;
+
       // -- met data
       seb.in.met.Us = std::max(wind_speed[0][c], min_wind_speed_);
       seb.in.met.QswIn = incoming_shortwave[0][c];
@@ -430,6 +438,10 @@ SurfaceBalanceExplicit::advance(double dt) {
       seb.in.met.Pr = precip_rain[0][c];
       seb.in.met.vp_air.temp = air_temp[0][c];
       seb.in.met.vp_air.relative_humidity = relative_humidity[0][c];
+
+      // -- snow thermal conductivity parameters
+      seb.params.snoK = snow_lambda_fresh_;
+      seb.params.snoKX = snow_lambda_exponent_;
 
       // -- smoothed/interpolated surface properties
       SEBPhysics::SurfaceParams surf_pars;

--- a/src/pks/surface_balance/explicit/surface_balance_explicit.hh
+++ b/src/pks/surface_balance/explicit/surface_balance_explicit.hh
@@ -62,6 +62,8 @@ public:
   double min_wind_speed_;
   double snow_ground_trans_;
   double min_snow_trans_;
+  double snow_lambda_fresh_;
+  double snow_lambda_exponent_;
 
   Teuchos::RCP<const AmanziMesh::Mesh> subsurf_mesh_;
 

--- a/src/pks/surface_balance/implicit/surface_balance_implicit.cc
+++ b/src/pks/surface_balance/implicit/surface_balance_implicit.cc
@@ -67,6 +67,10 @@ SurfaceBalanceImplicit::SurfaceBalanceImplicit(
   // Reading in Longwave Radation
   longwave_input_ = plist_->get<bool>("Longwave Input", false);
 
+  // snow thermal conductivity model parameters
+  snow_lambda_fresh_ = plist_->get<double>("thermal conductivity of fresh snow [W/m K]", 0.029);
+  snow_lambda_exponent_ = plist_->get<double>("thermal conductivity aging exponent for snow", 2.0);
+
   // transition snow depth
   snow_ground_trans_ = plist_->get<double>("snow-ground transitional depth", 0.02);
   min_snow_trans_ = plist_->get<double>("minimum snow transitional depth", 1.e-8);
@@ -479,6 +483,10 @@ SurfaceBalanceImplicit::Functional(double t_old, double t_new, Teuchos::RCP<Tree
       seb.out.snow_new = seb.in.snow_old;
       seb.in.vp_snow.temp = 273.15;
 
+      // -- snow thermal conductivity parameters
+      seb.params.snoK = snow_lambda_fresh_;
+      seb.params.snoKX = snow_lambda_exponent_;
+
       // -- met data
       seb.params.Zr = wind_speed_ref_ht_;
       seb.in.met.Us = std::max(wind_speed[0][c], min_wind_speed_);
@@ -584,6 +592,10 @@ SurfaceBalanceImplicit::Functional(double t_old, double t_new, Teuchos::RCP<Tree
       seb.in.snow_old.SWE = swe / theta;
       seb.out.snow_new = seb.in.snow_old;
       seb.in.vp_snow.temp = 273.15;
+
+      // -- snow thermal conductivity parameters
+      seb.params.snoK = snow_lambda_fresh_;
+      seb.params.snoKX = snow_lambda_exponent_;
 
       // -- met data
       seb.params.Zr = wind_speed_ref_ht_;

--- a/src/pks/surface_balance/implicit/surface_balance_implicit.hh
+++ b/src/pks/surface_balance/implicit/surface_balance_implicit.hh
@@ -78,6 +78,8 @@ public:
   double wind_speed_ref_ht_;
   double snow_ground_trans_;
   double min_snow_trans_;
+  double snow_lambda_fresh_;
+  double snow_lambda_exponent_;
 
   Teuchos::RCP<const AmanziMesh::Mesh> subsurf_mesh_;
 


### PR DESCRIPTION
Updates make it possible to specify two new parameters in the xml, used to calculate snow thermal conductivity as a function of density, in the surface energy balance pk.

The new parameters are the thermal conductivity of fresh snow, and the exponent used in the equation:

thermalK = thermalKofFreshSnow * 1e-4 * density ^ exponent

The parameters are entered into the xml as:
"thermal conductivity of fresh snow [W/m K]", "double"
"thermal conductivity aging exponent for snow", "double"