### PR TITLE
Fixes bugs in upwinding on surface flow

### DIFF
--- a/src/pks/flow/overland_pressure/overland_pressure.hh
+++ b/src/pks/flow/overland_pressure/overland_pressure.hh
@@ -163,7 +163,9 @@ protected:
   virtual void ApplyBoundaryConditions_(const Teuchos::Ptr<CompositeVector>& u,
           const Teuchos::Ptr<const CompositeVector>& elev);
 
-  virtual void FixBCsForOperator_(const Teuchos::Ptr<State>& S);
+  virtual void FixBCsForOperator_(const Teuchos::Ptr<State>& S,
+          const Teuchos::Ptr<Operators::PDE_Diffusion>& diff_op);
+  //virtual void FixBCsForFluxDirection_(const Teuchos::Ptr<State>& S);
   virtual void FixBCsForPrecon_(const Teuchos::Ptr<State>& S);
   // virtual void FixBCsForConsistentFaces_(const Teuchos::Ptr<State>& S);
 

--- a/src/pks/flow/overland_pressure/overland_pressure_physics.cc
+++ b/src/pks/flow/overland_pressure/overland_pressure_physics.cc
@@ -25,7 +25,7 @@ void OverlandPressureFlow::ApplyDiffusion_(const Teuchos::Ptr<State>& S,
   matrix_->Init();
   matrix_diff_->SetScalarCoefficient(cond, Teuchos::null);
   matrix_diff_->UpdateMatrices(Teuchos::null, Teuchos::null);
-  FixBCsForOperator_(S_next_.ptr()); // deals with zero gradient case
+  FixBCsForOperator_(S_next_.ptr(), matrix_diff_.ptr()); // deals with zero gradient case
   matrix_diff_->ApplyBCs(true, true, true);
 
   // derive fluxes -- this gets done independently fo update as precon does

--- a/src/pks/flow/overland_pressure/overland_pressure_ti.cc
+++ b/src/pks/flow/overland_pressure/overland_pressure_ti.cc
@@ -83,14 +83,8 @@ void OverlandPressureFlow::FunctionalResidual( double t_old,
     vecs.push_back(S_next_->GetFieldData(Keys::getKey(domain_,"ponded_depth_minus_depression_depth")).ptr());
     vecs.push_back(S_next_->GetFieldData(Keys::getKey(domain_,"fractional_conductance")).ptr());
   }
-
   db_->WriteVectors(vnames, vecs, true);
 #endif
-
-  db_->WriteVector("uw_dir", S_next_->GetFieldData(Keys::getKey(domain_,"mass_flux_direction")).ptr(), true);
-  db_->WriteVector("k_s", S_next_->GetFieldData(Keys::getKey(domain_,"overland_conductivity")).ptr(), true);
-  db_->WriteVector("k_s_uw", S_next_->GetFieldData(Keys::getKey(domain_,"upwind_overland_conductivity")).ptr(), true);
-  
   // update boundary conditions
   bc_head_->Compute(S_next_->time());
   bc_pressure_->Compute(S_next_->time());
@@ -104,12 +98,9 @@ void OverlandPressureFlow::FunctionalResidual( double t_old,
 
   // diffusion term, treated implicitly
   ApplyDiffusion_(S_next_.ptr(), res.ptr());
-
-  // debug after, as we need local matrices to calculate zero gradient BCs
-  db_->WriteBoundaryConditions(bc_markers(), bc_values());
   
 #if DEBUG_FLAG
-
+  db_->WriteBoundaryConditions(bc_markers(), bc_values());
   if (S_next_->HasField(Keys::getKey(domain_,"unfrozen_fraction"))) {
     vnames.resize(2);
     vecs.resize(2);
@@ -119,7 +110,6 @@ void OverlandPressureFlow::FunctionalResidual( double t_old,
     vecs[1] = S_next_->GetFieldData(Keys::getKey(domain_,"unfrozen_fraction")).ptr();
     db_->WriteVectors(vnames, vecs, false);
   }
-
   db_->WriteVector("uw_dir", S_next_->GetFieldData(Keys::getKey(domain_,"mass_flux_direction")).ptr(), true);
   db_->WriteVector("k_s", S_next_->GetFieldData(Keys::getKey(domain_,"overland_conductivity")).ptr(), true);
   db_->WriteVector("k_s_uw", S_next_->GetFieldData(Keys::getKey(domain_,"upwind_overland_conductivity")).ptr(), true);
@@ -128,7 +118,6 @@ void OverlandPressureFlow::FunctionalResidual( double t_old,
 #endif
 
   // accumulation term
-  
   AddAccumulation_(res.ptr());
 
 #if DEBUG_FLAG


### PR DESCRIPTION
fixes bugs in upwinding with zero gradient condition, and fixes display error in overland conductivity for Neumann boundary faces.  Some of these changes may need to be moved into Richards and energy equations as well, at least the upwinding on Neumann face issues, but this will take some thought to make sure they don't break surface-subsurface coupling via boundary_face.

Addresses #11 

This probably isn't complete yet -- it needs to deal with the same issue in the subsurface, and potentially with advection of energy as well?