### PR TITLE
Fix bug in daymet_to_ats.py

### DIFF
--- a/tools/utils/daymet_to_ats.py
+++ b/tools/utils/daymet_to_ats.py
@@ -123,17 +123,17 @@ def get_argument_parser():
     
     def string_to_start_date(s):
         if len(s) == 4:
-            return datetime.datetime(int(s),1,1)
+            return datetime.datetime(int(s),1,1).date()
         else:
-            return datetime.datetime.strptime(s, '%Y-%m-%d')
+            return datetime.datetime.strptime(s, '%Y-%m-%d').date()
     parser.add_argument('-s', '--start', type=string_to_start_date,
                         help='Start date, either YYYY or YYYY-MM-DD')
 
     def string_to_end_date(s):
         if len(s) == 4:
-            return datetime.datetime(int(s),12,31)
+            return datetime.datetime(int(s),12,31).date()
         else:
-            return datetime.datetime.strptime(s, '%Y-%m-%d')
+            return datetime.datetime.strptime(s, '%Y-%m-%d').date()
     parser.add_argument('-e', '--end', type=string_to_end_date,
                         help='End date, either YYYY or YYYY-MM-DD')
 


### PR DESCRIPTION
In the prior version, start and end dates were read in `datetime` format (at L126, L128, L134, and L136).  This triggered an error when comparing with `date`-formatted bounds in the method `validate_start_end` at L156 and L163.  Fixed this by converting input strings to `date` format.