### PR TITLE
Modify calculation of sat_vapor_pressure only

### DIFF
--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_funcs.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_funcs.cc
@@ -105,10 +105,18 @@ double SaturatedVaporPressure(double temp)
 {
   // Sat vap. press o/water Dingman D-7 (Bolton, 1980)
   // *** (Bolton, 1980) Calculates vapor pressure in [KPa]  ****
-  double tempC = temp - 273.15;
-  double vp_mbar = 6.112 * std::exp(17.67 * tempC / (tempC + 243.5));
+//  double tempC = temp - 273.15;
+//  double vp_mbar = 6.112 * std::exp(17.67 * tempC / (tempC + 243.5));
   // convert to Pa
-  return 1e2 * vp_mbar;
+//  return 1e2 * vp_mbar;
+
+  // August–Roche–Magnus formula (Westermann et al., 2016), Pa
+  double double tempC = temp - 273.15;
+  if (tempC > 0) {
+    return 611 * std::exp(17.62 * tempC /(tempC + 243.12));
+  } else {
+    return 611 * std::exp(22.46 * tempC /(tempC + 272.62));
+  }
 }
 
 double SaturatedVaporPressureELM(double temp)

--- a/tools/utils/daymet_to_ats.py
+++ b/tools/utils/daymet_to_ats.py
@@ -83,7 +83,13 @@ def daymet_to_ats(dat):
     precip_ms = dat['prcp_mmday'] / 1.e3 / 86400.
     
     # Sat vap. press o/water Dingman D-7 (Bolton, 1980)
-    sat_vp_Pa = 611.2 * np.exp(17.67 * mean_air_temp_c / (mean_air_temp_c + 243.5))
+    # sat_vp_Pa = 611.2 * np.exp(17.67 * mean_air_temp_c / (mean_air_temp_c + 243.5))
+
+    # August–Roche–Magnus formula (Westermann et al., 2016)
+    if mean_air_temp_c > 0:
+        sat_vp_Pa = 611 * np.exp(17.62 * mean_air_temp_c /(mean_air_temp_c + 243.12))
+    else:
+        sat_vp_Pa = 611 * np.exp(22.46 * mean_air_temp_c /(mean_air_temp_c + 272.62))
 
     dout['time [s]'] = np.arange(0, len(dat), 1)*86400.
     dout['air temperature [K]'] = 273.15 + mean_air_temp_c


### PR DESCRIPTION
Modified the calculation formula for saturated vapor pressure for ATS and daymet_to_ats. The forcing data for ATS still requires relative humidity.