### PR TITLE
WIP: Modify sat_vapor_pressure in ATS and forcing needs vapor pressure instead of RH

### DIFF
--- a/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_drag_term.hh
+++ b/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_drag_term.hh
@@ -1,0 +1,52 @@
+#pragma once
+#include <cmath>
+
+namespace Amanzi {
+namespace Flow {
+namespace SutraIceTerm {
+
+//inline double 
+//dragcoef(double sl, double si, double sr, double omega) 
+//{
+//  return std::pow(10, -omega * si / (sl + si - sr + 1e-6));
+//}
+//
+//inline double 
+//d_dragcoef_dsl(double sl, double si, double sr, double omega) 
+//{
+//  double coef = std::pow(10, -omega * si / (sl + si - sr + 1e-6));
+//  return coef * std::log(10) * omega *si * std::pow(sl + si -sr + 1e-6, -2);
+//}
+//
+//inline double 
+//d_dragcoef_dsi(double sl, double si, double sr, double omega) 
+//{
+//  double coef = std::pow(10, -omega * si / (sl + si - sr + 1e-6));  
+//  return coef * std::log(10) * omega * (sr - sl) * std::pow(sl + si - sr + 1e-6, -2);
+//}
+
+
+inline double 
+dragcoef(double sl, double sg, double sr, double omega) 
+{
+  return std::pow(10, -omega * (1 - sl - sg) / (1 - sg - sr + 1e-6));
+}
+
+inline double 
+d_dragcoef_dsl(double sl, double sg, double sr, double omega) 
+{
+  double coef = std::pow(10, -omega * (1 - sl - sg) / (1 - sg - sr + 1e-6));
+  return coef * std::log(10) * omega / (1 - sg -sr + 1e-6);
+}
+
+inline double 
+d_dragcoef_dsg(double sl, double sg, double sr, double omega) 
+{
+  double coef = std::pow(10, -omega * (1 - sl - sg) / (1 - sg - sr + 1e-6));  
+  return coef * std::log(10) * omega * (sl - sr) * std::pow(1 - sg - sr + 1e-6, -2);
+}
+
+
+} // namespace
+} // namespace
+} // namespace

--- a/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_evaluator.hh
@@ -52,8 +52,8 @@ Some additional parameters are available.
 
 */
 
-#ifndef AMANZI_FLOWRELATIONS_REL_PERM_EVALUATOR_
-#define AMANZI_FLOWRELATIONS_REL_PERM_EVALUATOR_
+#ifndef AMANZI_FLOWRELATIONS_REL_PERM_SUTRAICE_EVALUATOR_
+#define AMANZI_FLOWRELATIONS_REL_PERM_SUTRAICE_EVALUATOR_
 
 #include "wrm.hh"
 #include "wrm_partition.hh"
@@ -63,7 +63,7 @@ Some additional parameters are available.
 namespace Amanzi {
 namespace Flow {
 
-enum class BoundaryRelPerm {
+enum class BoundarySutraIceRelPerm {
   BOUNDARY_PRESSURE,
   INTERIOR_PRESSURE,
   HARMONIC_MEAN,
@@ -72,17 +72,17 @@ enum class BoundaryRelPerm {
   SURF_REL_PERM
 };
 
-class RelPermEvaluator : public SecondaryVariableFieldEvaluator {
+class RelPermSutraIceEvaluator : public SecondaryVariableFieldEvaluator {
 
  public:
   // constructor format for all derived classes
   explicit
-  RelPermEvaluator(Teuchos::ParameterList& plist);
+  RelPermSutraIceEvaluator(Teuchos::ParameterList& plist);
 
-  RelPermEvaluator(Teuchos::ParameterList& plist,
+  RelPermSutraIceEvaluator(Teuchos::ParameterList& plist,
                    const Teuchos::RCP<WRMPartition>& wrms);
 
-  RelPermEvaluator(const RelPermEvaluator& other) = default;
+  RelPermSutraIceEvaluator(const RelPermSutraIceEvaluator& other) = default;
   virtual Teuchos::RCP<FieldEvaluator> Clone() const;
 
   virtual void EnsureCompatibility(const Teuchos::Ptr<State>& S);
@@ -103,20 +103,21 @@ class RelPermEvaluator : public SecondaryVariableFieldEvaluator {
   Teuchos::RCP<WRMPartition> wrms_;
   Key sat_key_;
   Key sat_gas_key_;
+  Key sat_ice_key_;
   Key dens_key_;
   Key visc_key_;
   Key surf_rel_perm_key_;
 
   bool is_dens_visc_;
   Key surf_domain_;
-  BoundaryRelPerm boundary_krel_;
+  BoundarySutraIceRelPerm boundary_krel_;
 
   double perm_scale_;
   double min_val_;
-  double beta_;
+  double omega_;
 
  private:
-  static Utils::RegisteredFactory<FieldEvaluator,RelPermEvaluator> factory_;
+  static Utils::RegisteredFactory<FieldEvaluator,RelPermSutraIceEvaluator> factory_;
 };
 
 } //namespace

--- a/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_evaluator_reg.hh
+++ b/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_evaluator_reg.hh
@@ -1,0 +1,10 @@
+#include "rel_perm_sutraice_evaluator.hh"
+
+namespace Amanzi {
+namespace Flow {
+
+// registry of method
+Utils::RegisteredFactory<FieldEvaluator,RelPermSutraIceEvaluator> RelPermSutraIceEvaluator::factory_("SutraIce rel perm");
+
+} //namespace
+} //namespace

--- a/src/pks/flow/permafrost.hh
+++ b/src/pks/flow/permafrost.hh
@@ -65,6 +65,9 @@ public:
   // Virtual destructor
   virtual ~Permafrost() {}
 
+  // 
+  bool sutra_kr_;
+
 protected:
   // Create of physical evaluators.
   virtual void SetupPhysicalEvaluators_(const Teuchos::Ptr<State>& S);

--- a/src/pks/surface_balance/constitutive_relations/land_cover/longwave_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/longwave_evaluator.cc
@@ -37,10 +37,10 @@ LongwaveEvaluator::LongwaveEvaluator(Teuchos::ParameterList& plist) :
   auto domain = Keys::getDomain(my_key_);
   air_temp_key_ = Keys::readKey(plist, domain, "air temperature", "air_temperature");
   dependencies_.insert(air_temp_key_);
-  rel_hum_key_ = Keys::readKey(plist, domain, "relative humidity", "relative_humidity");
-  dependencies_.insert(rel_hum_key_);
+  vp_air_key_ = Keys::readKey(plist, domain, "vapor pressure air", "vapor_pressure_air");
+  dependencies_.insert(vp_air_key_);
 
-  min_rel_hum_ = plist.get<double>("minimum relative humidity [-]", 0.1);
+//  min_rel_hum_ = plist.get<double>("minimum relative humidity [-]", 0.1);
   scale_ = plist.get<double>("scaling factor [-]", 1.0);
 }
 
@@ -50,11 +50,11 @@ LongwaveEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
         const Teuchos::Ptr<CompositeVector>& result)
 {
   const auto& air_temp = *S->GetFieldData(air_temp_key_)->ViewComponent("cell", false);
-  const auto& rel_hum = *S->GetFieldData(rel_hum_key_)->ViewComponent("cell", false);
+  const auto& vp_air = *S->GetFieldData(vp_air_key_)->ViewComponent("cell", false);
   auto& res = *result->ViewComponent("cell", false);
 
   for (int c=0; c!=res.MyLength(); ++c) {
-    res[0][c] = scale_ * Relations::IncomingLongwaveRadiation(air_temp[0][c], std::max(min_rel_hum_, rel_hum[0][c]));
+    res[0][c] = scale_ * Relations::IncomingLongwaveRadiation(air_temp[0][c], vp_air[0][c]);
   }
 }
 

--- a/src/pks/surface_balance/constitutive_relations/land_cover/longwave_evaluator.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/longwave_evaluator.hh
@@ -52,8 +52,8 @@ class LongwaveEvaluator : public SecondaryVariableFieldEvaluator {
 
  protected:
 
-  Key air_temp_key_, rel_hum_key_;
-  double min_rel_hum_, scale_;
+  Key air_temp_key_, vp_air_key_;
+  double scale_; // min_rel_hum_, scale_;
 
  private:
   static Utils::RegisteredFactory<FieldEvaluator,LongwaveEvaluator> reg_;

--- a/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.cc
@@ -84,8 +84,8 @@ PETPriestleyTaylorEvaluator::PETPriestleyTaylorEvaluator(Teuchos::ParameterList&
   surf_temp_key_ = Keys::readKey(plist, domain_, "surface temperature", "temperature");
   dependencies_.insert(surf_temp_key_);
 
-  rel_hum_key_ = Keys::readKey(plist, domain_, "relative humidity", "relative_humidity");
-  dependencies_.insert(rel_hum_key_);
+  vp_air_key_ = Keys::readKey(plist, domain_, "vapor pressure air", "vapor_pressure_air");
+  dependencies_.insert(vp_air_key_);
 
   elev_key_ = Keys::readKey(plist, domain_, "elevation", "elevation");
   dependencies_.insert(elev_key_);
@@ -115,7 +115,7 @@ PETPriestleyTaylorEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
 {
   const auto& air_temp = *S->GetFieldData(air_temp_key_)->ViewComponent("cell", false);
   const auto& surf_temp = *S->GetFieldData(surf_temp_key_)->ViewComponent("cell", false);
-  const auto& rel_hum = *S->GetFieldData(rel_hum_key_)->ViewComponent("cell", false);
+  const auto& vp_air = *S->GetFieldData(vp_air_key_)->ViewComponent("cell", false);
   const auto& elev = *S->GetFieldData(elev_key_)->ViewComponent("cell", false);
   const auto& rad = *S->GetFieldData(rad_key_)->ViewComponent("cell",false);
 

--- a/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.cc
@@ -105,6 +105,8 @@ PETPriestleyTaylorEvaluator::PETPriestleyTaylorEvaluator(Teuchos::ParameterList&
   if (one_minus_limiter_) {
     one_minus_limiter_key_ = Keys::readKey(plist, domain_, "1 - limiter");
     dependencies_.insert(one_minus_limiter_key_);
+    one_minus_limiter_nvecs_ = plist.get<int>("1 - limiter number of dofs", 1);
+    one_minus_limiter_dof_ = plist.get<int>("1 - limiter dof", 0);
   }
 }
 
@@ -180,12 +182,12 @@ PETPriestleyTaylorEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
     const auto& limiter = *S->GetFieldData(one_minus_limiter_key_)->ViewComponent("cell", false);
 #ifdef ENABLE_DBC
     double limiter_max, limiter_min;
-    limiter.MaxValue(&limiter_max);
-    limiter.MinValue(&limiter_min);
+    limiter(one_minus_limiter_dof_)->MaxValue(&limiter_max);
+    limiter(one_minus_limiter_dof_)->MinValue(&limiter_min);
     AMANZI_ASSERT(limiter_max <= 1 + 1e-10);
     AMANZI_ASSERT(limiter_min >= -1e-10);
 #endif
-    res.Multiply(-1, limiter, res, 1);
+    res(0)->Multiply(-1, *limiter(one_minus_limiter_dof_), *res(0), 1);
   }
 }
 
@@ -207,11 +209,11 @@ PETPriestleyTaylorEvaluator::EvaluateFieldPartialDerivative_(const Teuchos::Ptr<
   } else if (one_minus_limiter_ && wrt_key == one_minus_limiter_key_) {
     const auto& limiter = *S->GetFieldData(one_minus_limiter_key_)->ViewComponent("cell", false);
     const auto& evap_val = *S->GetFieldData(my_key_)->ViewComponent("cell", false);
-    auto& res_c = *result->ViewComponent("cell", false);
-    res_c.ReciprocalMultiply(-1, limiter, evap_val, 0);
+    auto& res_c = *(*result->ViewComponent("cell", false))(0);
+    res_c.ReciprocalMultiply(-1, *limiter(one_minus_limiter_dof_), *evap_val(0), 0);
     for (int c=0; c!=res_c.MyLength(); ++c) {
-      if (limiter[0][c] < 1.e-5) {
-        res_c[0][c] = 0.;
+      if (limiter[one_minus_limiter_dof_][c] < 1.e-5) {
+        res_c[c] = 0.;
       }
     }
   }
@@ -243,6 +245,10 @@ PETPriestleyTaylorEvaluator::EnsureCompatibility(const Teuchos::Ptr<State>& S)
         fac->SetMesh(S->GetMesh(domain_))
           ->SetGhosted()
           ->AddComponent("cell", AmanziMesh::CELL, limiter_nvecs_);
+      } else if (dep_key == one_minus_limiter_key_) {
+        fac->SetMesh(S->GetMesh(domain_))
+          ->SetGhosted()
+          ->AddComponent("cell", AmanziMesh::CELL, one_minus_limiter_nvecs_);
       } else {
         fac->SetMesh(S->GetMesh(domain_))
           ->SetGhosted()

--- a/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.hh
@@ -17,15 +17,19 @@ Requires the following dependencies:
 .. _pet-priestley-taylor-evaluator-spec:
 .. admonition:: pet-priestley-taylor-evaluator-spec:
 
-   * `"include limiter`" ``[bool]`` If true, multiply potential ET by a limiter
-     to get an actual ET.
+   * `"include limiter`" ``[bool]`` **false** If true, multiply potential ET by
+     a limiter to get an actual ET.
    * `"limiter number of dofs`" ``[int]`` **1** Area fractions are often used
      as limiters, and these have multiple dofs.  This provides how many.
    * `"limiter dof`" ``[int]`` **0** Area fractions are often used
      as limiters, and these have multiple dofs.  This provides which one to use.
-   * `"include 1 - limiter`" ``[bool]`` If true, multiply potential ET by
-     1 - a limiter (e.g. a limiter that partitions between two pools) to get
-     actual ET.
+   * `"include 1 - limiter`" ``[bool]`` **false** If true, multiply potential
+     ET by 1 - a limiter (e.g. a limiter that partitions between two pools) to
+     get actual ET.
+   * `"1 - limiter number of dofs`" ``[int]`` **1** Area fractions are often used
+     as limiters, and these have multiple dofs.  This provides how many.
+   * `"1 - limiter dof`" ``[int]`` **0** Area fractions are often used
+     as limiters, and these have multiple dofs.  This provides which one to use.
    * `"sublimate snow`" ``[bool]`` **false** If true, use latent heat of
       vaporization of snow, not water.
 
@@ -124,10 +128,9 @@ class PETPriestleyTaylorEvaluator : public SecondaryVariableFieldEvaluator {
   Key one_minus_limiter_key_;
 
   double pt_alpha_;
-  bool limiter_;
-  int limiter_nvecs_;
-  int limiter_dof_;
-  bool one_minus_limiter_;
+  bool limiter_, one_minus_limiter_;
+  int limiter_nvecs_, one_minus_limiter_nvecs_;
+  int limiter_dof_, one_minus_limiter_dof_;
   bool compatible_;
 
   LandCoverMap land_cover_;

--- a/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/pet_priestley_taylor_evaluator.hh
@@ -117,7 +117,7 @@ class PETPriestleyTaylorEvaluator : public SecondaryVariableFieldEvaluator {
   Key evap_type_;
   Key air_temp_key_;
   Key surf_temp_key_;
-  Key rel_hum_key_;
+  Key vp_air_key_;
   Key elev_key_;
   Key rad_key_;
   Key limiter_key_;

--- a/src/pks/surface_balance/constitutive_relations/land_cover/radiation_balance_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/radiation_balance_evaluator.cc
@@ -134,16 +134,24 @@ RadiationBalanceEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
       double lw_atm_surf = Relations::BeersLaw(lw_in[0][c], lc.second.beers_k_lw, lai[0][c]);
       double lw_atm_can = lw_in[0][c] - lw_atm_surf;
 
+      // smooth between lai = 0 (no canopy = no outgoing longwave) to lai = 1
+      // (lai of 1 approximately indicates the entire grid cell is covered in
+      // leaf area?)
+      double lai_factor = lai[0][c] < 1. ? lai[0][c] : 1.;
+
       // black-body radiation for LW out
       double lw_surf = Relations::OutgoingLongwaveRadiation(temp_surf[0][c], emiss[0][c]);
       double lw_snow = Relations::OutgoingLongwaveRadiation(temp_snow[0][c], emiss[1][c]);
-      double lw_can = Relations::OutgoingLongwaveRadiation(temp_canopy[0][c],
+      double lw_can = lai_factor * Relations::OutgoingLongwaveRadiation(temp_canopy[0][c],
               lc.second.emissivity_canopy);
 
       rad_bal_surf[0][c] = (1-albedo[0][c])*sw_atm_surf + lw_atm_surf + lw_can - lw_surf;
       rad_bal_snow[0][c] = (1-albedo[1][c])*sw_atm_surf + lw_atm_surf + lw_can - lw_snow;
-      rad_bal_can[0][c] = (1-lc.second.albedo_canopy)*sw_atm_can + lw_atm_can
-        + area_frac[1][c]*lw_snow + area_frac[0][c]*lw_surf - 2*lw_can;
+      rad_bal_can[0][c] = (1-lc.second.albedo_canopy)*sw_atm_can
+        + lw_atm_can
+        + lai_factor * area_frac[1][c] * lw_snow
+        + lai_factor * area_frac[0][c] * lw_surf
+        - 2*lw_can;
     }
   }
 }

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_defs.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_defs.hh
@@ -46,8 +46,6 @@ struct ModelParams {
       density_air(1.275),       // [kg/m^3]
       density_freshsnow(100.),  // [kg/m^3]
       density_frost(200.),      // [kg/m^3]
-      density_snow_max(325.),   // [kg/m^3] // based on observations at Barrow, AK
-      thermalK_freshsnow(0.029),// thermal conductivity of fresh snow [W/m K]
       thermalK_snow_exp(2),     // exponent in thermal conductivity of snow model [-]
       H_fusion(333500.0),       // Heat of fusion for melting snow -- [J/kg]
       H_sublimation(2834000.),  // Latent heat of sublimation ------- [J/kg]
@@ -56,17 +54,14 @@ struct ModelParams {
       Cv_water(4218.636),       // Specific heat of water ----------- [J/K kg]
       P_atm(101325.),           // atmospheric pressure ------------- [Pa]
       gravity(9.807),           // gravity [kg m / s^2]
-      evap_transition_width(100.), // transition on evaporation from surface to
+      evap_transition_width(100.) // transition on evaporation from surface to
                                    // evaporation from subsurface [m],
                                    // THIS IS DEPRECATED
-      Clapp_Horn_b(1.)          // Clapp and Hornberger "b" [-]
   {}
 
   ModelParams(Teuchos::ParameterList& plist) :
       ModelParams() {
-    thermalK_freshsnow = plist.get<double>("thermal conductivity of fresh snow [W m^-1 K^-1]", thermalK_freshsnow);
     thermalK_snow_exp = plist.get<double>("thermal conductivity of snow aging exponent [-]", thermalK_snow_exp);
-    density_snow_max = plist.get<double>("max density of snow [kg m^-3]", density_snow_max);
     evap_transition_width = plist.get<double>("evaporation transition width [Pa]", evap_transition_width);
   }
 
@@ -76,12 +71,9 @@ struct ModelParams {
   double density_air;
   double density_freshsnow;
   double density_frost;
-  double density_snow_max;
-  double thermalK_freshsnow;
   double thermalK_snow_exp;
   double H_fusion, H_sublimation, H_vaporization;
   double Cp_air, Cv_water;
-  double Clapp_Horn_b;
 
   // other parameters
   double evap_transition_width;
@@ -96,6 +88,7 @@ struct GroundProperties {
   double porosity;                      // [-]
   double density_w;                     // density [kg/m^3]
   double dz;                            // [m]
+  double clapp_horn_b;                  // [-]
   double albedo;                        // [-]
   double emissivity;                    // [-]
   double saturation_gas;                // [-]
@@ -114,9 +107,10 @@ struct GroundProperties {
       emissivity(NaN),
       saturation_gas(NaN),
       roughness(NaN),
+      clapp_horn_b(3),
       snow_death_rate(0.),
       unfrozen_fraction(0.),
-      water_transition_depth(0.02)
+      water_transition_depth(0.01)
   {}
 
   void UpdateVaporPressure();
@@ -131,6 +125,7 @@ struct SnowProperties {
   double albedo;                // [-]
   double emissivity;            // [-]
   double roughness;             // [m] surface roughness of a snow-covered domain
+  double thermalK_freshsnow;    // thermal conductivity of fresh snow [W/m K]
 
   SnowProperties() :
       height(NaN),
@@ -138,7 +133,8 @@ struct SnowProperties {
       temp(NaN),
       albedo(NaN),
       emissivity(NaN),
-      roughness(NaN)
+      roughness(NaN),
+      thermalK_freshsnow(NaN)
   {}
 };
 
@@ -147,6 +143,7 @@ struct SnowProperties {
 struct MetData {
   double Us;                    // wind speed, [m/s]
   double Z_Us;
+  double KB;
   double QswIn;                 // incoming short-wave radiation, [W/m^2]
   double QlwIn;                 // incoming longwave radiaton, [W/m^2]
   double Ps;                    // precip snow, [m (SWE)/s]
@@ -158,6 +155,7 @@ struct MetData {
   MetData() :
       Us(NaN),
       Z_Us(NaN),
+      KB(NaN),
       QswIn(NaN),
       QlwIn(NaN),
       Ps(NaN),
@@ -232,7 +230,7 @@ struct SurfaceParams {
   SurfaceParams() :
       a_tundra(0.135),           // [-] Grenfell and Perovich, (2004)
       a_water(0.1168),           // [-] Cogley J.G. (1979)
-      a_ice(0.44),              // [-] deteriorated ice, Grenfell and Perovich, (2004)
+      a_ice(0.44),              // [-] deteriorated ice, Grenfell and Perovich, (2004) 0.44
       e_snow(0.98),             // [-] emissivity for snow, From P. ReVelle (Thesis)
       e_tundra(0.92),           // [-] emissivity for tundra, From P. ReVelle
                                 //         (Thesis), Ling & Zhang, 2004

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_defs.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_defs.hh
@@ -152,7 +152,8 @@ struct MetData {
   double Ps;                    // precip snow, [m (SWE)/s]
   double Pr;                    // precip rain, [m/s]
   double air_temp;              // air temperature [K]
-  double relative_humidity;     // relative humidity [-]
+  double vapor_pressure_air;    // vapor pressure air [Pa]
+//  double relative_humidity;     // relative humidity [-]
 
   MetData() :
       Us(NaN),
@@ -162,7 +163,8 @@ struct MetData {
       Ps(NaN),
       Pr(NaN),
       air_temp(NaN),
-      relative_humidity(NaN) {}
+      vapor_pressure_qir(NaN) {}
+//      relative_humidity(NaN) {}
 };
 
 

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_funcs.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_funcs.hh
@@ -31,7 +31,7 @@ double CalcRoughnessFactor(double snow_height, double Z_rough_bare, double Z_rou
 //
 // Calculate longwave from air temp and relative humidity
 // ------------------------------------------------------------------------------------------
-double IncomingLongwaveRadiation(double air_temp, double relative_humidity);
+double IncomingLongwaveRadiation(double air_temp, double vapor_pressure_air);
 
 //
 // Calculates incoming shortwave and longwave radiation incident on surface
@@ -76,7 +76,7 @@ double SaturatedSpecificHumidityELM(double temp);
 // Partial pressure of water vapor in air.
 // In [kPa]
 // ------------------------------------------------------------------------------------------
-double VaporPressureAir(double air_temp, double relative_humidity);
+//double VaporPressureAir(double air_temp, double relative_humidity);
 
 //
 // Partial pressure of water vapor in gaseous phase, in the soil.
@@ -93,7 +93,7 @@ double VaporPressureGround(const GroundProperties& surf, const ModelParams& para
 double EvaporativeResistanceGround(const GroundProperties& surf,
         const MetData& met,
         const ModelParams& params,
-        double vapor_pressure_air, double vapor_pressure_ground);
+        double vapor_pressure_ground);
 
 double EvaporativeResistanceCoef(double saturation_gas,
         double porosity, double dessicated_zone_thickness, double Clapp_Horn_b);

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_funcs.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_physics_funcs.hh
@@ -52,7 +52,7 @@ double BeersLaw(double sw_in, double k_extinction, double lai);
 //
 // Wind speed term D_he
 // ------------------------------------------------------------------------------------------
-double WindFactor(double Us, double Z_Us, double Z_rough, double c_von_Karman);
+double WindFactor(double Us, double Z_Us, double Z_rough, double c_von_Karman, double KB);
 
 //
 // Stability of convective overturning term Zeta AKA Sqig

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.cc
@@ -108,8 +108,10 @@ SEBThreeComponentEvaluator::SEBThreeComponentEvaluator(Teuchos::ParameterList& p
   dependencies_.insert(met_lw_key_);
   met_air_temp_key_ = Keys::readKey(plist, domain_,"air temperature", "air_temperature");
   dependencies_.insert(met_air_temp_key_);
-  met_rel_hum_key_ = Keys::readKey(plist, domain_,"relative humidity", "relative_humidity");
-  dependencies_.insert(met_rel_hum_key_);
+//  met_rel_hum_key_ = Keys::readKey(plist, domain_,"relative humidity", "relative_humidity");
+//  dependencies_.insert(met_rel_hum_key_);
+  met_vp_air_key_ = Keys::readKey(plist, domain_,"vapor pressure air", "vapor_pressure_air");
+  dependencies_.insert(met_vp_air_key_);
   met_wind_speed_key_ = Keys::readKey(plist, domain_,"wind speed", "wind_speed");
   dependencies_.insert(met_wind_speed_key_);
   met_prain_key_ = Keys::readKey(plist, domain_,"precipitation rain", "precipitation_rain");
@@ -155,7 +157,7 @@ SEBThreeComponentEvaluator::SEBThreeComponentEvaluator(Teuchos::ParameterList& p
   dependencies_.insert(ss_pres_key_);
 
   // parameters
-  min_rel_hum_ = plist.get<double>("minimum relative humidity [-]", 0.1);
+//  min_rel_hum_ = plist.get<double>("minimum relative humidity [-]", 0.1);
   min_wind_speed_ = plist.get<double>("minimum wind speed [m s^-1]", 1.0);
   wind_speed_ref_ht_ = plist.get<double>("wind speed reference height [m]", 2.0);
   AMANZI_ASSERT(wind_speed_ref_ht_ > 0.);
@@ -171,7 +173,8 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
   const auto& qSW_in = *S->GetFieldData(met_sw_key_)->ViewComponent("cell",false);
   const auto& qLW_in = *S->GetFieldData(met_lw_key_)->ViewComponent("cell",false);
   const auto& air_temp = *S->GetFieldData(met_air_temp_key_)->ViewComponent("cell",false);
-  const auto& rel_hum = *S->GetFieldData(met_rel_hum_key_)->ViewComponent("cell",false);
+//  const auto& rel_hum = *S->GetFieldData(met_rel_hum_key_)->ViewComponent("cell",false);
+  const auto& vp_air = *S->GetFieldData(met_vp_air_key_)->ViewComponent("cell",false);
   const auto& wind_speed = *S->GetFieldData(met_wind_speed_key_)->ViewComponent("cell",false);
   const auto& Prain = *S->GetFieldData(met_prain_key_)->ViewComponent("cell",false);
   const auto& Psnow = *S->GetFieldData(met_psnow_key_)->ViewComponent("cell",false);
@@ -258,7 +261,8 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
       met.QswIn = qSW_in[0][c];
       met.QlwIn = qLW_in[0][c];
       met.air_temp = air_temp[0][c];
-      met.relative_humidity = std::max(rel_hum[0][c], min_rel_hum_);
+      met.vapor_pressure_air = vp_air[0][c];
+//      met.relative_humidity = std::max(rel_hum[0][c], min_rel_hum_);
       met.Pr = Prain[0][c];
 
       // bare ground column
@@ -479,8 +483,10 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
     vecs.clear();
     vnames.push_back("air_temp");
     vecs.push_back(S->GetFieldData(met_air_temp_key_).ptr());
-    vnames.push_back("rel_hum");
-    vecs.push_back(S->GetFieldData(met_rel_hum_key_).ptr());
+//    vnames.push_back("rel_hum");
+//    vecs.push_back(S->GetFieldData(met_rel_hum_key_).ptr());
+    vnames.push_back("vp_air");
+    vecs.push_back(S->GetFieldData(met_vp_air_key_).ptr());
     vnames.push_back("precip_rain");
     vecs.push_back(S->GetFieldData(met_prain_key_).ptr());
     vnames.push_back("precip_snow");

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.cc
@@ -155,12 +155,15 @@ SEBThreeComponentEvaluator::SEBThreeComponentEvaluator(Teuchos::ParameterList& p
   dependencies_.insert(poro_key_);
   ss_pres_key_ = Keys::readKey(plist, domain_ss_, "subsurface pressure", "pressure");
   dependencies_.insert(ss_pres_key_);
+  
 
   // parameters
 //  min_rel_hum_ = plist.get<double>("minimum relative humidity [-]", 0.1);
   min_wind_speed_ = plist.get<double>("minimum wind speed [m s^-1]", 1.0);
   wind_speed_ref_ht_ = plist.get<double>("wind speed reference height [m]", 2.0);
   AMANZI_ASSERT(wind_speed_ref_ht_ > 0.);
+  thermalK_freshsnow_ = plist.get<double>("thermal conductivity of fresh snow [W m^-1 K^-1]", 0.029);
+  KB_ = plist.get<double>("log ratio between z0m and z0h [-]", 0.);
 }
 
 void
@@ -199,6 +202,8 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
   const auto& sat_gas = *S->GetFieldData(sat_gas_key_)->ViewComponent("cell",false);
   const auto& poro = *S->GetFieldData(poro_key_)->ViewComponent("cell",false);
   const auto& ss_pres = *S->GetFieldData(ss_pres_key_)->ViewComponent("cell",false);
+
+
 
   // collect output vecs
   auto& water_source = *results[0]->ViewComponent("cell",false);
@@ -257,6 +262,7 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
       // met data structure
       Relations::MetData met;
       met.Z_Us = wind_speed_ref_ht_;
+      met.KB = KB_;
       met.Us = std::max(wind_speed[0][c], min_wind_speed_);
       met.QswIn = qSW_in[0][c];
       met.QlwIn = qLW_in[0][c];
@@ -273,6 +279,7 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
         surf.roughness = lc.second.roughness_ground;
         surf.density_w = mass_dens[0][c];
         surf.dz = lc.second.dessicated_zone_thickness;
+        surf.clapp_horn_b = lc.second.clapp_horn_b;
         surf.albedo = sg_albedo[0][c];
         surf.emissivity = emissivity[0][c];
         surf.ponded_depth = 0.; // by definition
@@ -340,6 +347,7 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
         surf.roughness = lc.second.roughness_ground;
         surf.density_w = mass_dens[0][c];
         surf.dz = lc.second.dessicated_zone_thickness;
+        surf.clapp_horn_b = lc.second.clapp_horn_b;
         surf.emissivity = emissivity[1][c];
         surf.albedo = sg_albedo[1][c];
         surf.ponded_depth = std::max(lc.second.water_transition_depth,
@@ -408,6 +416,7 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
         surf.roughness = lc.second.roughness_ground;
         surf.density_w = mass_dens[0][c];
         surf.dz = lc.second.dessicated_zone_thickness;
+        surf.clapp_horn_b = lc.second.clapp_horn_b;
         surf.emissivity = emissivity[2][c];
         surf.albedo = sg_albedo[2][c];
         surf.ponded_depth = 0; // does not matter
@@ -431,6 +440,8 @@ SEBThreeComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
         snow.albedo = surf.albedo;
         snow.emissivity = surf.emissivity;
         snow.roughness = lc.second.roughness_snow;
+        
+        snow.thermalK_freshsnow = thermalK_freshsnow_;
 
         const Relations::EnergyBalance eb = Relations::UpdateEnergyBalanceWithSnow(surf, met, params, snow);
         const Relations::MassBalance mb = Relations::UpdateMassBalanceWithSnow(surf, params, eb);

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.hh
@@ -141,7 +141,7 @@ class SEBThreeComponentEvaluator : public SecondaryVariablesFieldEvaluator {
   Key water_source_key_, energy_source_key_;
   Key ss_water_source_key_, ss_energy_source_key_;
   Key snow_source_key_, new_snow_key_;
-  Key met_sw_key_, met_lw_key_, met_air_temp_key_, met_rel_hum_key_;
+  Key met_sw_key_, met_lw_key_, met_air_temp_key_, met_vp_air_key_; //met_rel_hum_key_;
   Key met_wind_speed_key_, met_prain_key_, met_psnow_key_;
   Key snow_depth_key_, snow_dens_key_, snow_death_rate_key_;
   Key ponded_depth_key_, unfrozen_fraction_key_;
@@ -159,7 +159,7 @@ class SEBThreeComponentEvaluator : public SecondaryVariablesFieldEvaluator {
   Key domain_ss_;
   Key domain_snow_;
 
-  double min_rel_hum_;       // relative humidity of 0 causes problems -- large evaporation
+//  double min_rel_hum_;       // relative humidity of 0 causes problems -- large evaporation
   double min_wind_speed_;       // wind speed of 0, under this model, would have 0 latent or sensible heat?
   double wind_speed_ref_ht_;    // reference height of the met data
 

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_threecomponent_evaluator.hh
@@ -162,6 +162,8 @@ class SEBThreeComponentEvaluator : public SecondaryVariablesFieldEvaluator {
 //  double min_rel_hum_;       // relative humidity of 0 causes problems -- large evaporation
   double min_wind_speed_;       // wind speed of 0, under this model, would have 0 latent or sensible heat?
   double wind_speed_ref_ht_;    // reference height of the met data
+  double KB_;
+  double thermalK_freshsnow_;
 
   LandCoverMap land_cover_;
 

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_twocomponent_evaluator.cc
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_twocomponent_evaluator.cc
@@ -112,8 +112,10 @@ SEBTwoComponentEvaluator::SEBTwoComponentEvaluator(Teuchos::ParameterList& plist
   dependencies_.insert(met_lw_key_);
   met_air_temp_key_ = Keys::readKey(plist, domain_,"air temperature", "air_temperature");
   dependencies_.insert(met_air_temp_key_);
-  met_rel_hum_key_ = Keys::readKey(plist, domain_,"relative humidity", "relative_humidity");
-  dependencies_.insert(met_rel_hum_key_);
+//  met_rel_hum_key_ = Keys::readKey(plist, domain_,"relative humidity", "relative_humidity");
+//  dependencies_.insert(met_rel_hum_key_);
+  met_vp_air_key_ = Keys::readKey(plist, domain_,"vapor pressure air", "vapor_pressure_air");
+  dependencies_.insert(met_vp_air_key_);
   met_wind_speed_key_ = Keys::readKey(plist, domain_,"wind speed", "wind_speed");
   dependencies_.insert(met_wind_speed_key_);
   met_prain_key_ = Keys::readKey(plist, domain_,"precipitation rain", "precipitation_rain");
@@ -176,7 +178,8 @@ SEBTwoComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
   const auto& qSW_in = *S->GetFieldData(met_sw_key_)->ViewComponent("cell",false);
   const auto& qLW_in = *S->GetFieldData(met_lw_key_)->ViewComponent("cell",false);
   const auto& air_temp = *S->GetFieldData(met_air_temp_key_)->ViewComponent("cell",false);
-  const auto& rel_hum = *S->GetFieldData(met_rel_hum_key_)->ViewComponent("cell",false);
+//  const auto& rel_hum = *S->GetFieldData(met_rel_hum_key_)->ViewComponent("cell",false);
+  const auto& vp_air = *S->GetFieldData(met_vp_air_key_)->ViewComponent("cell",false);
   const auto& wind_speed = *S->GetFieldData(met_wind_speed_key_)->ViewComponent("cell",false);
   const auto& Prain = *S->GetFieldData(met_prain_key_)->ViewComponent("cell",false);
   const auto& Psnow = *S->GetFieldData(met_psnow_key_)->ViewComponent("cell",false);
@@ -262,7 +265,8 @@ SEBTwoComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
       met.QswIn = qSW_in[0][c];
       met.QlwIn = qLW_in[0][c];
       met.air_temp = air_temp[0][c];
-      met.relative_humidity = std::max(rel_hum[0][c], min_rel_hum_);
+      met.vapor_pressure_air = vp_air[0][c];
+//      met.relative_humidity = std::max(rel_hum[0][c], min_rel_hum_);
       met.Pr = Prain[0][c];
 
       // non-snow covered column
@@ -427,8 +431,10 @@ SEBTwoComponentEvaluator::EvaluateField_(const Teuchos::Ptr<State>& S,
     vecs.clear();
     vnames.push_back("air_temp");
     vecs.push_back(S->GetFieldData(met_air_temp_key_).ptr());
-    vnames.push_back("rel_hum");
-    vecs.push_back(S->GetFieldData(met_rel_hum_key_).ptr());
+//    vnames.push_back("rel_hum");
+//    vecs.push_back(S->GetFieldData(met_rel_hum_key_).ptr());
+    vnames.push_back("vp_air");
+    vecs.push_back(S->GetFieldData(met_vp_air_key_).ptr());
     vnames.push_back("precip_rain");
     vecs.push_back(S->GetFieldData(met_prain_key_).ptr());
     vnames.push_back("precip_snow");

--- a/src/pks/surface_balance/constitutive_relations/land_cover/seb_twocomponent_evaluator.hh
+++ b/src/pks/surface_balance/constitutive_relations/land_cover/seb_twocomponent_evaluator.hh
@@ -138,7 +138,7 @@ class SEBTwoComponentEvaluator : public SecondaryVariablesFieldEvaluator {
   Key water_source_key_, energy_source_key_;
   Key ss_water_source_key_, ss_energy_source_key_;
   Key snow_source_key_, new_snow_key_;
-  Key met_sw_key_, met_lw_key_, met_air_temp_key_, met_rel_hum_key_;
+  Key met_sw_key_, met_lw_key_, met_air_temp_key_, met_vp_air_key_; //met_rel_hum_key_;
   Key met_wind_speed_key_, met_prain_key_, met_psnow_key_;
   Key snow_depth_key_, snow_dens_key_, snow_death_rate_key_;
   Key ponded_depth_key_, unfrozen_fraction_key_;

--- a/src/pks/surface_balance/surface_balance_implicit_subgrid.hh
+++ b/src/pks/surface_balance/surface_balance_implicit_subgrid.hh
@@ -95,6 +95,9 @@ public:
   Key snow_source_key_;
   Key snow_death_rate_key_;
   Key area_frac_key_;
+  
+  double density_snow_max_;
+  
 
  private:
   // factory registration

--- a/tools/utils/daymet_to_ats.py
+++ b/tools/utils/daymet_to_ats.py
@@ -83,12 +83,12 @@ def daymet_to_ats(dat):
     precip_ms = dat['prcp_mmday'] / 1.e3 / 86400.
     
     # Sat vap. press o/water Dingman D-7 (Bolton, 1980)
-    sat_vp_Pa = 611.2 * np.exp(17.67 * mean_air_temp_c / (mean_air_temp_c + 243.5))
+    # sat_vp_Pa = 611.2 * np.exp(17.67 * mean_air_temp_c / (mean_air_temp_c + 243.5))
 
     dout['time [s]'] = np.arange(0, len(dat), 1)*86400.
     dout['air temperature [K]'] = 273.15 + mean_air_temp_c
     dout['incoming shortwave radiation [W m^-2]'] = dat['dayl_s']/86400*dat['srad_Wm2']
-    dout['relative humidity [-]'] = np.minimum(1.0, dat['vp_Pa']/sat_vp_Pa)
+    dout['vapor pressure [Pa]'] = dat['vp_Pa']
 
     dout['precipitation rain [m s^-1]'] = np.where(mean_air_temp_c >= 0, precip_ms, 0)
     dout['precipitation snow [m SWE s^-1]'] = np.where(mean_air_temp_c < 0, precip_ms, 0)


### PR DESCRIPTION
Modified the calculation formula for the saturated vapor pressure in ATS. The calculation of saturated vapor pressure and RH  was deleted in daymet_to_ats. ATS requires vapor pressure of air as forcing directly instead of RH. In this case, 'surface-relative_humidity' in the input xml file should be changed to 'surface-vapor_pressure_air'.