### PR TITLE
fixes SWI runs by getting the right water content

### DIFF
--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: amanzi/amanzi
-        ref: konstantin/state
+        ref: master
         submodules: true
     - name: Extract the Amanzi branch name
       id: amanzi_branch

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Extract the Amanzi branch name
       id: amanzi_branch
       run:
-        echo "::set-output name=AMANZI_BRANCH::$(echo $GITHUB_REF | sed -e 's/refs\/heads\///')"
+        echo "::set-output name=AMANZI_BRANCH::$(echo master)"
     - name: Extract the ATS branch name
       id: branch
       working-directory: Docker

--- a/src/pks/flow/constitutive_relations/water_content/overland_pressure_multicomponent_water_content_evaluator.cc
+++ b/src/pks/flow/constitutive_relations/water_content/overland_pressure_multicomponent_water_content_evaluator.cc
@@ -1,21 +1,20 @@
 /* -*-  mode: c++; indent-tabs-mode: nil -*- */
 
 /*
-  Evaluator for determining height( rho, head )
+  Evaluator for determining amount of water on the surface based on density and pressure
 
-  Authors: Ethan Coon (ecoon@lanl.gov)
+  Authors: Daniil Svyatsky(dasvyat@lanl.gov)
 */
 
-#include "overland_pressure_water_content_evaluator.hh"
+#include "overland_pressure_multicomponent_water_content_evaluator.hh"
 
 namespace Amanzi {
 namespace Flow {
 
 
-OverlandPressureWaterContentEvaluator::OverlandPressureWaterContentEvaluator(Teuchos::ParameterList& plist) :
+OverlandPressureMulticomponentWaterContentEvaluator::OverlandPressureMulticomponentWaterContentEvaluator(Teuchos::ParameterList& plist) :
     EvaluatorSecondaryMonotypeCV(plist)
 {
-  M_ = plist_.get<double>("molar mass", 0.0180153);
   bar_ = plist_.get<bool>("allow negative water content", false);
   rollover_ = plist_.get<double>("water content rollover", 0.);
 
@@ -25,24 +24,35 @@ OverlandPressureWaterContentEvaluator::OverlandPressureWaterContentEvaluator(Teu
   // my dependencies
   pres_key_ = Keys::readKey(plist_, domain_name, "pressure", "pressure");
   dependencies_.insert(KeyTag{pres_key_, tag});
+
+  mass_dens_key_ = Keys::readKey(plist_, domain_name, "mass density", "mass_density_liquid");
+  dependencies_.insert(KeyTag{mass_dens_key_, tag});
+  molar_dens_key_ = Keys::readKey(plist_, domain_name, "molar density", "molar_density_liquid");
+  dependencies_.insert(KeyTag{molar_dens_key_, tag});
+
   cv_key_ = Keys::readKey(plist_, domain_name, "cell volume", "cell_volume");
   dependencies_.insert(KeyTag{cv_key_, tag});
 }
 
 
 Teuchos::RCP<Evaluator>
-OverlandPressureWaterContentEvaluator::Clone() const {
-  return Teuchos::rcp(new OverlandPressureWaterContentEvaluator(*this));
+OverlandPressureMulticomponentWaterContentEvaluator::Clone() const {
+  return Teuchos::rcp(new OverlandPressureMulticomponentWaterContentEvaluator(*this));
 }
 
 
-void OverlandPressureWaterContentEvaluator::Evaluate_(const State& S,
+void OverlandPressureMulticomponentWaterContentEvaluator::Evaluate_(const State& S,
         const std::vector<CompositeVector*>& result)
 {
   Tag tag = my_keys_.front().second;
   Epetra_MultiVector& res = *result[0]->ViewComponent("cell",false);
   const Epetra_MultiVector& pres = *S.GetPtr<CompositeVector>(pres_key_, tag)
       ->ViewComponent("cell",false);
+  const Epetra_MultiVector& molar_dens = *S.GetPtr<CompositeVector>(molar_dens_key_, tag)
+      ->ViewComponent("cell",false);
+  const Epetra_MultiVector& mass_dens = *S.GetPtr<CompositeVector>(mass_dens_key_, tag)
+      ->ViewComponent("cell",false);
+
 
   const Epetra_MultiVector& cv = *S.GetPtr<CompositeVector>(cv_key_, tag)
       ->ViewComponent("cell",false);
@@ -54,7 +64,7 @@ void OverlandPressureWaterContentEvaluator::Evaluate_(const State& S,
   int ncells = res.MyLength();
   if (bar_) {
     for (int c=0; c!=ncells; ++c) {
-      res[0][c] = cv[0][c] * (pres[0][c] - p_atm) / (gz * M_);
+      res[0][c] = cv[0][c] * molar_dens[0][c] * (pres[0][c] - p_atm) / (mass_dens[0][c] * gz);
     }
   } else if (rollover_ > 0.) {
     for (int c=0; c!=ncells; ++c) {
@@ -63,26 +73,31 @@ void OverlandPressureWaterContentEvaluator::Evaluate_(const State& S,
           dp < rollover_ ?
             dp*dp/(2*rollover_) :
             dp - rollover_/2.;
-      res[0][c] = cv[0][c] * dp_eff / (gz * M_);
+      res[0][c] = cv[0][c] * molar_dens[0][c] * dp_eff / (mass_dens[0][c] * gz);
     }
   } else {
     for (int c=0; c!=ncells; ++c) {
       res[0][c] = pres[0][c] < p_atm ? 0. :
-          cv[0][c] * (pres[0][c] - p_atm) / (gz * M_);
+        cv[0][c] * molar_dens[0][c] * (pres[0][c] - p_atm) / (mass_dens[0][c] * gz);
     }
   }
 }
 
 
-void OverlandPressureWaterContentEvaluator::EvaluatePartialDerivative_(const State& S,
-        const Key& wrt_key, const Tag& wrt_tag,
-        const std::vector<CompositeVector*>& result)
+void OverlandPressureMulticomponentWaterContentEvaluator::EvaluatePartialDerivative_(
+  const State& S,
+  const Key& wrt_key, const Tag& wrt_tag,
+  const std::vector<CompositeVector*>& result)
 {
   Tag tag = my_keys_.front().second;
   AMANZI_ASSERT(wrt_key == pres_key_);
 
   Epetra_MultiVector& res = *result[0]->ViewComponent("cell",false);
   const Epetra_MultiVector& pres = *S.GetPtr<CompositeVector>(pres_key_, tag)
+      ->ViewComponent("cell",false);
+  const Epetra_MultiVector& molar_dens = *S.GetPtr<CompositeVector>(molar_dens_key_, tag)
+      ->ViewComponent("cell",false);
+  const Epetra_MultiVector& mass_dens = *S.GetPtr<CompositeVector>(mass_dens_key_, tag)
       ->ViewComponent("cell",false);
 
   const Epetra_MultiVector& cv = *S.GetPtr<CompositeVector>(cv_key_, tag)
@@ -96,19 +111,19 @@ void OverlandPressureWaterContentEvaluator::EvaluatePartialDerivative_(const Sta
     int ncells = res.MyLength();
     if (bar_) {
       for (int c=0; c!=ncells; ++c) {
-        res[0][c] = cv[0][c] / (gz * M_);
+        res[0][c] = cv[0][c] * molar_dens[0][c] / (mass_dens[0][c] * gz);
       }
     } else if (rollover_ > 0.) {
       for (int c=0; c!=ncells; ++c) {
         double dp = pres[0][c] - p_atm;
         double ddp_eff = dp < 0. ? 0. :
           dp < rollover_ ? dp/rollover_ : 1.;
-        res[0][c] = cv[0][c] * ddp_eff / (gz * M_);
+        res[0][c] = cv[0][c] * ddp_eff * molar_dens[0][c] / (mass_dens[0][c] * gz);
       }
     } else {
       for (int c=0; c!=ncells; ++c) {
         res[0][c] = pres[0][c] < p_atm ? 0. :
-          cv[0][c] / (gz * M_);
+          cv[0][c] * molar_dens[0][c] / (mass_dens[0][c] * gz);
       }
     }
   } else {

--- a/src/pks/flow/constitutive_relations/water_content/overland_pressure_multicomponent_water_content_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/water_content/overland_pressure_multicomponent_water_content_evaluator.hh
@@ -1,0 +1,52 @@
+/* -*-  mode: c++; indent-tabs-mode: nil -*- */
+
+/*
+  Evaluator for determining height( rho, head )
+
+  Authors: Daniil Svyatsky
+*/
+
+#pragma once
+
+#include "EvaluatorSecondaryMonotype.hh"
+#include "Factory.hh"
+
+namespace Amanzi {
+namespace Flow {
+
+class OverlandPressureMulticomponentWaterContentEvaluator : public EvaluatorSecondaryMonotypeCV {
+
+ public:
+  // constructor format for all derived classes
+  explicit
+  OverlandPressureMulticomponentWaterContentEvaluator(Teuchos::ParameterList& plist);
+  OverlandPressureMulticomponentWaterContentEvaluator(const OverlandPressureMulticomponentWaterContentEvaluator& other) = default;
+
+  virtual Teuchos::RCP<Evaluator> Clone() const override;
+
+ protected:
+  void InitializeFromPlist_();
+
+  // Required methods from EvaluatorSecondaryMonotypeCV
+  virtual void Evaluate_(const State& S,
+          const std::vector<CompositeVector*>& result) override;
+  virtual void EvaluatePartialDerivative_(const State& S,
+          const Key& wrt_key, const Tag& wrt_tag,
+          const std::vector<CompositeVector*>& result) override;
+
+ protected:
+  Key pres_key_;
+  Key cv_key_;
+  Key mass_dens_key_, molar_dens_key_;
+
+  bool bar_;  // bar'd variable indicates this is potentially negative for
+              // pressures less than atmospheric
+  double rollover_;
+
+ private:
+  static Utils::RegisteredFactory<Evaluator,OverlandPressureMulticomponentWaterContentEvaluator> reg_;
+
+};
+
+} //namespace
+} //namespace

--- a/src/pks/flow/constitutive_relations/water_content/overland_pressure_multicomponent_water_content_evaluator_reg.hh
+++ b/src/pks/flow/constitutive_relations/water_content/overland_pressure_multicomponent_water_content_evaluator_reg.hh
@@ -1,0 +1,7 @@
+#include "overland_pressure_multicomponent_water_content_evaluator.hh"
+namespace Amanzi {
+namespace Flow {
+Utils::RegisteredFactory<Evaluator,OverlandPressureMulticomponentWaterContentEvaluator>
+OverlandPressureMulticomponentWaterContentEvaluator::reg_("overland pressure multicomponent water content");
+}
+}

--- a/src/pks/transport/sediment_transport/organic_matter_evaluator.hh
+++ b/src/pks/transport/sediment_transport/organic_matter_evaluator.hh
@@ -7,8 +7,7 @@
   Authors: Daniil Svyatsky (dasvyat@lanl.gov)
 */
 
-#ifndef AMANZI_ORGANICMATTER_EVALUATOR_
-#define AMANZI_ORGANICMATTER_EVALUATOR_
+#pragma once
 
 // TPLs
 #include "Teuchos_ParameterList.hpp"
@@ -21,22 +20,12 @@ namespace Amanzi {
 class OrganicMatterRateEvaluator : public EvaluatorSecondaryMonotypeCV {
 
  public:
-  explicit
-  OrganicMatterRateEvaluator(Teuchos::ParameterList& plist);
+  explicit OrganicMatterRateEvaluator(Teuchos::ParameterList& plist);
+  OrganicMatterRateEvaluator(const OrganicMatterRateEvaluator& other) = default;
+  virtual Teuchos::RCP<Evaluator> Clone() const override;
 
-  OrganicMatterRateEvaluator(const OrganicMatterRateEvaluator& other);
-  virtual Teuchos::RCP<Evaluator> Clone() const;
-  
-  // virtual void EvaluateElevationAndSlope_(const Teuchos::Ptr<State>& S,
-  //         const std::vector<Teuchos::Ptr<CompositeVector> >& results) = 0;
-
-  // virtual bool HasFieldChanged(const Teuchos::Ptr<State>& S, Key request);
-
-  //virtual void EnsureCompatibility(const Teuchos::Ptr<State>& S){};
-
-protected:
-
-    // Required methods from EvaluatorSecondaryMonotypeCV
+ protected:
+  // Required methods from EvaluatorSecondaryMonotypeCV
   virtual void Evaluate_(const State& S,
           const std::vector<CompositeVector*>& result) override;
   virtual void EvaluatePartialDerivative_(const State& S,
@@ -45,6 +34,7 @@ protected:
 
   double Bmax_;
   double Q_db0_;
+  double Q_on_Bmax_;
   Key biomass_key_;
 
   static Utils::RegisteredFactory<Evaluator,OrganicMatterRateEvaluator> factory_;
@@ -53,4 +43,3 @@ protected:
 
 } //namespace
 
-#endif

--- a/src/pks/transport/sediment_transport/settlement_evaluator.cc
+++ b/src/pks/transport/sediment_transport/settlement_evaluator.cc
@@ -12,24 +12,26 @@
 
 namespace Amanzi {
 
-SettlementRateEvaluator :: SettlementRateEvaluator(Teuchos::ParameterList& plist) :
-  EvaluatorSecondaryMonotypeCV(plist) {
-
+SettlementRateEvaluator::SettlementRateEvaluator(Teuchos::ParameterList& plist)
+  : EvaluatorSecondaryMonotypeCV(plist)
+{
   Tag tag = my_keys_.front().second;
   Key domain_name = Keys::getDomain(my_keys_.front().first);
-  
-  velocity_key_ = plist_.get<std::string>("velocity key",
-                                     Keys::getKey(domain_name,"velocity"));
 
-  sediment_key_ =  plist_.get<std::string>("sediment key",
-                                     Keys::getKey(domain_name,"sediment"));
+  velocity_key_ = Keys::readKey(plist_, domain_name, "velocity", "velocity");
+
+  // note, this is a proxy for velocity, which does not have an eval yet
+  Key pres_key = Keys::readKey(plist_, domain_name, "pressure", "pressure");
+  dependencies_.insert(KeyTag{pres_key, tag});
+
+  sediment_key_ = Keys::readKey(plist_, domain_name, "sediment", "sediment");
+  dependencies_.insert(KeyTag{sediment_key_, tag});
 
   tau_d_ = plist_.get<double>("critical shear stress");
   ws_ = plist_.get<double>("settling velocity");
   gamma_ = plist_.get<double>("specific weight of water");
   sediment_density_ = plist_.get<double>("sediment density [kg m^-3]");
 
-  
   umax_ = plist_.get<double>("max current");
   xi_ = plist_.get<double>("Chezy parameter");
   Cf_ = plist_.get<double>("drag coefficient");
@@ -37,59 +39,39 @@ SettlementRateEvaluator :: SettlementRateEvaluator(Teuchos::ParameterList& plist
   double pi = boost::math::constants::pi<double>();
 
   lambda_ = 8./(3*pi) * (umax_/(xi_*xi_));
-    
-  dependencies_.insert(KeyTag{"surface-pressure", tag});
-  dependencies_.insert(KeyTag{sediment_key_, tag});
-    
 }
 
-  
-SettlementRateEvaluator ::SettlementRateEvaluator (const SettlementRateEvaluator & other) :
-  EvaluatorSecondaryMonotypeCV(other),
-  velocity_key_(other.velocity_key_), sediment_key_(other.sediment_key_) {
 
-  tau_d_ = other.tau_d_;
-  ws_ = other.ws_;
-  gamma_ = other.gamma_;
-  lambda_ = other.lambda_;
-  sediment_density_ = other.sediment_density_;
-  Cf_ = other.Cf_;
-} 
-
-
-Teuchos::RCP<Evaluator> SettlementRateEvaluator ::Clone() const {
-  return Teuchos::rcp(new SettlementRateEvaluator (*this));
+Teuchos::RCP<Evaluator> SettlementRateEvaluator::Clone() const
+{
+  return Teuchos::rcp(new SettlementRateEvaluator(*this));
 }
 
 
 void SettlementRateEvaluator::Evaluate_(const State& S,
-                                        const std::vector<CompositeVector*>& result){
-
+                                        const std::vector<CompositeVector*>& result)
+{
   Tag tag = my_keys_.front().second;
-  
-  const Epetra_MultiVector& vel = *S.GetPtr<CompositeVector>(velocity_key_, tag)->ViewComponent("cell");
-  const Epetra_MultiVector& tcc = *S.GetPtr<CompositeVector>(sediment_key_, tag)->ViewComponent("cell");
+  const Epetra_MultiVector& vel = *S.Get<CompositeVector>(velocity_key_, tag).ViewComponent("cell");
+  const Epetra_MultiVector& tcc = *S.Get<CompositeVector>(sediment_key_, tag).ViewComponent("cell");
   Epetra_MultiVector& result_c = *result[0]->ViewComponent("cell");
-  
-  for (int c=0; c<result_c.MyLength(); c++){
+
+  for (int c=0; c<result_c.MyLength(); c++) {
     //double tau_0 = gamma_ * lambda_ * (sqrt(vel[0][c] * vel[0][c] + vel[1][c] * vel[1][c]));
     double tau_0 = gamma_ * Cf_ * (sqrt(vel[0][c] * vel[0][c] + vel[1][c] * vel[1][c])*sqrt(vel[0][c] * vel[0][c] + vel[1][c] * vel[1][c]));
-    
-    if (tau_0 < tau_d_){
+    if (tau_0 < tau_d_) {
       result_c[0][c] = sediment_density_ * ws_ * std::min(tcc[0][c], 0.5) * (1 - tau_0 / tau_d_);
-    }else{
+    } else {
       result_c[0][c] = 0.;
     }
-
   }
-   
 }
 
 void SettlementRateEvaluator::EvaluatePartialDerivative_(const State& S,
-                                                      const Key& wrt_key, const Tag& wrt_tag,
-                                                      const std::vector<CompositeVector*>& result){
-   AMANZI_ASSERT(0); 
+        const Key& wrt_key, const Tag& wrt_tag,
+        const std::vector<CompositeVector*>& result)
+{
+   AMANZI_ASSERT(0);
 }
-  
-  
+
 } // namespace

--- a/src/pks/transport/sediment_transport/settlement_evaluator.hh
+++ b/src/pks/transport/sediment_transport/settlement_evaluator.hh
@@ -21,21 +21,12 @@ namespace Amanzi {
 class SettlementRateEvaluator : public EvaluatorSecondaryMonotypeCV {
 
  public:
-  explicit
-  SettlementRateEvaluator(Teuchos::ParameterList& plist);
-  SettlementRateEvaluator(const SettlementRateEvaluator& other);
-  virtual Teuchos::RCP<Evaluator> Clone() const;
-  
-  // virtual void EvaluateElevationAndSlope_(const Teuchos::Ptr<State>& S,
-  //         const std::vector<Teuchos::Ptr<CompositeVector> >& results) = 0;
+  explicit SettlementRateEvaluator(Teuchos::ParameterList& plist);
+  SettlementRateEvaluator(const SettlementRateEvaluator& other) = default;
+  virtual Teuchos::RCP<Evaluator> Clone() const override;
 
-  // virtual bool HasFieldChanged(const Teuchos::Ptr<State>& S, Key request);
-
-  //virtual void EnsureCompatibility(const Teuchos::Ptr<State>& S){};
-
-protected:
-
-    // Required methods from EvaluatorSecondaryMonotypeCV
+ protected:
+  // Required methods from EvaluatorSecondaryMonotypeCV
   virtual void Evaluate_(const State& S,
           const std::vector<CompositeVector*>& result) override;
   virtual void EvaluatePartialDerivative_(const State& S,

--- a/src/pks/transport/sediment_transport/trapping_evaluator.cc
+++ b/src/pks/transport/sediment_transport/trapping_evaluator.cc
@@ -16,96 +16,80 @@ TrappingRateEvaluator :: TrappingRateEvaluator(Teuchos::ParameterList& plist) :
 
   Tag tag = my_keys_.front().second;
   Key domain_name = Keys::getDomain(my_keys_.front().first);
-  
-  velocity_key_ = plist_.get<std::string>("velocity key",
-                                          Keys::getKey(domain_name,"velocity"));
-  
-  sediment_key_ =  plist_.get<std::string>("sediment key",
-                                           Keys::getKey(domain_name,"sediment"));
 
-  ponded_depth_key_ =  plist_.get<std::string>("ponded depth key",
-                                           Keys::getKey(domain_name,"ponded_depth"));
+  velocity_key_ = Keys::readKey(plist_, domain_name, "velocity", "velocity");
 
-  biomass_key_ = Keys::getKey(domain_name, "biomass");
-  
+  // note, this is a proxy for velocity, which does not have an eval yet
+  Key pres_key = Keys::readKey(plist_, domain_name, "pressure", "pressure");
+  dependencies_.insert(KeyTag{pres_key, tag});
+
+  sediment_key_ = Keys::readKey(plist_, domain_name, "sediment", "sediment");
+  dependencies_.insert(KeyTag{sediment_key_, tag});
+
+  ponded_depth_key_ = Keys::readKey(plist_, domain_name, "ponded depth", "ponded_depth");
+  dependencies_.insert(KeyTag{ponded_depth_key_, tag});
+
+  biomass_key_ = Keys::readKey(plist_, domain_name, "biomass", "biomass");
+  dependencies_.insert(KeyTag{biomass_key_, tag});
+
+  // Please put units on all of these! --etc
   visc_ = plist_.get<double>("kinematic viscosity");
   d_p_ = plist_.get<double>("particle diameter");
   alpha_ = plist_.get<double>("alpha");
   beta_ = plist_.get<double>("beta");
   gamma_ = plist_.get<double>("gamma");
-  sediment_density_ = plist_.get<double>("sediment density [kg m^-3]");  
-
-  dependencies_.insert(KeyTag{"surface-pressure", tag});
-  dependencies_.insert(KeyTag{sediment_key_, tag});
-  dependencies_.insert(KeyTag{ponded_depth_key_, tag});
-  dependencies_.insert(KeyTag{biomass_key_, tag});
-    
+  sediment_density_ = plist_.get<double>("sediment density [kg m^-3]");
 }
 
-  
-TrappingRateEvaluator ::TrappingRateEvaluator (const TrappingRateEvaluator & other) :
-  EvaluatorSecondaryMonotypeCV(other),
-  velocity_key_(other.velocity_key_),
-  sediment_key_(other.sediment_key_),
-  ponded_depth_key_(other.ponded_depth_key_)
+
+Teuchos::RCP<Evaluator>
+TrappingRateEvaluator::Clone() const
 {
-  visc_ = other.visc_;
-  d_p_ = other.d_p_;
-  alpha_ = other.alpha_;
-  gamma_ = other.gamma_;
-  beta_  = other.beta_;
-  sediment_density_ = other.sediment_density_;
-} 
-
-
-Teuchos::RCP<Evaluator> TrappingRateEvaluator ::Clone() const {
-  return Teuchos::rcp(new TrappingRateEvaluator (*this));
+  return Teuchos::rcp(new TrappingRateEvaluator(*this));
 }
 
 
 void TrappingRateEvaluator::Evaluate_(const State& S,
-                                      const std::vector<CompositeVector*>& result){
-
+                                      const std::vector<CompositeVector*>& result)
+{
   Tag tag = my_keys_.front().second;
-  
-  const Epetra_MultiVector& vel = *S.GetPtr<CompositeVector>(velocity_key_, tag)->ViewComponent("cell");
-  const Epetra_MultiVector& tcc = *S.GetPtr<CompositeVector>(sediment_key_, tag)->ViewComponent("cell");
-  const Epetra_MultiVector& depth = *S.GetPtr<CompositeVector>(ponded_depth_key_, tag)->ViewComponent("cell");
-  const Epetra_MultiVector& bio_n = *S.GetPtr<CompositeVector>("surface-stem_density", tag)->ViewComponent("cell");
-  const Epetra_MultiVector& bio_d = *S.GetPtr<CompositeVector>("surface-stem_diameter", tag)->ViewComponent("cell");
-  const Epetra_MultiVector& bio_h = *S.GetPtr<CompositeVector>("surface-stem_height", tag)->ViewComponent("cell");
+
+  const Epetra_MultiVector& vel = *S.Get<CompositeVector>(velocity_key_, tag).ViewComponent("cell");
+  const Epetra_MultiVector& tcc = *S.Get<CompositeVector>(sediment_key_, tag).ViewComponent("cell");
+  const Epetra_MultiVector& depth = *S.Get<CompositeVector>(ponded_depth_key_, tag).ViewComponent("cell");
+  const Epetra_MultiVector& bio_n = *S.Get<CompositeVector>("surface-stem_density", tag).ViewComponent("cell");
+  const Epetra_MultiVector& bio_d = *S.Get<CompositeVector>("surface-stem_diameter", tag).ViewComponent("cell");
+  const Epetra_MultiVector& bio_h = *S.Get<CompositeVector>("surface-stem_height", tag).ViewComponent("cell");
   Epetra_MultiVector& result_c = *result[0]->ViewComponent("cell");
 
   result_c.PutScalar(0.);
-  
-  for (int c=0; c<result_c.MyLength(); c++){
 
-    for (int j=0; j<bio_n.NumVectors(); j++){
+  for (int c=0; c<result_c.MyLength(); c++) {
+    for (int j=0; j<bio_n.NumVectors(); j++) {
 
       double h_s = bio_h[j][c];
       double d_s = bio_d[j][c];
       double n_s = bio_n[j][c];
-    
+
       double u_abs = sqrt(vel[0][c] * vel[0][c] + vel[1][c] * vel[1][c]);
       double eps;
-      if (d_s > 1e-12){
+      if (d_s > 1e-12) {
         eps = alpha_ * std::pow(u_abs*d_s/visc_, beta_) * std::pow(d_p_/d_s, gamma_);
-      }else{
+      } else {
         eps = 0.;
-      }      
+      }
 
       result_c[0][c] += sediment_density_ * tcc[0][c] * u_abs * eps * d_s * n_s * std::min(depth[0][c], h_s);
     }
   }
-      
-
 }
+
 
 void TrappingRateEvaluator::EvaluatePartialDerivative_(const State& S,
                                                       const Key& wrt_key, const Tag& wrt_tag,
-                                                      const std::vector<CompositeVector*>& result){
-   AMANZI_ASSERT(0); 
+                                                      const std::vector<CompositeVector*>& result)
+{
+  AMANZI_ASSERT(0);
 }
-  
-  
+
 } // namespace

--- a/src/pks/transport/sediment_transport/trapping_evaluator.hh
+++ b/src/pks/transport/sediment_transport/trapping_evaluator.hh
@@ -6,9 +6,7 @@
 
   Authors: Daniil Svyatsky (dasvyat@lanl.gov)
 */
-
-#ifndef AMANZI_TRAPPINGRATE_EVALUATOR_
-#define AMANZI_TRAPPINGRATE_EVALUATOR_
+#pragma once
 
 // TPLs
 #include "Teuchos_ParameterList.hpp"
@@ -24,36 +22,25 @@ class TrappingRateEvaluator : public EvaluatorSecondaryMonotypeCV {
   explicit
   TrappingRateEvaluator(Teuchos::ParameterList& plist);
 
-  TrappingRateEvaluator(const TrappingRateEvaluator& other);
-  virtual Teuchos::RCP<Evaluator> Clone() const;
-  
-  // virtual void EvaluateElevationAndSlope_(const Teuchos::Ptr<State>& S,
-  //         const std::vector<Teuchos::Ptr<CompositeVector> >& results) = 0;
+  TrappingRateEvaluator(const TrappingRateEvaluator& other) = default;
+  virtual Teuchos::RCP<Evaluator> Clone() const override;
 
-  // virtual bool HasFieldChanged(const Teuchos::Ptr<State>& S, Key request);
-
-  //virtual void EnsureCompatibility(const Teuchos::Ptr<State>& S){};
-
-  protected:
-
-
-    // Required methods from EvaluatorSecondaryMonotypeCV
+ protected:
+  // Required methods from EvaluatorSecondaryMonotypeCV
   virtual void Evaluate_(const State& S,
           const std::vector<CompositeVector*>& result) override;
   virtual void EvaluatePartialDerivative_(const State& S,
-          const Key& wrt_key, const Tag& wrt_tag, const std::vector<CompositeVector*>& result) override;  
+          const Key& wrt_key, const Tag& wrt_tag, const std::vector<CompositeVector*>& result) override;
 
   double visc_, d_p_, alpha_, beta_, gamma_;
 
   Key velocity_key_;
   Key sediment_key_;
   Key ponded_depth_key_;
-  Key biomass_key_;  
+  Key biomass_key_;
   double sediment_density_;
-  static Utils::RegisteredFactory<Evaluator,TrappingRateEvaluator> factory_;
 
+  static Utils::RegisteredFactory<Evaluator,TrappingRateEvaluator> factory_;
 };
 
 } //namespace
-
-#endif


### PR DESCRIPTION
Adds surface WC eval that deals with salinity/other multicomponent liquids.

Note this is based on @dasvyat  PR from branch dsv/fix_swi that someone merged in some code from 1.2 and was not clean.  This simply adds an evaluator, along with cleaning up sediment transport evaluators to avoid compiler warnings, use readKey, and other best practices.