### PR TITLE
adds extraction evaluator to take fields from parent meshes to derived meshes

### DIFF
--- a/src/constitutive_relations/CMakeLists.txt
+++ b/src/constitutive_relations/CMakeLists.txt
@@ -75,6 +75,11 @@ register_evaluator_with_factory(
   LISTNAME ATS_RELATIONS_REG
   )
 
+register_evaluator_with_factory(
+  HEADERFILE generic_evaluators/ExtractionEvaluator_reg.hh
+  LISTNAME ATS_RELATIONS_REG
+  )
+
 generate_evaluators_registration_header(
   HEADERFILE ats_relations_registration.hh
   LISTNAME   ATS_RELATIONS_REG

--- a/src/constitutive_relations/generic_evaluators/CMakeLists.txt
+++ b/src/constitutive_relations/generic_evaluators/CMakeLists.txt
@@ -10,6 +10,7 @@ set(ats_generic_evals_src_files
     SubgridDisaggregateEvaluator.cc
     SubgridAggregateEvaluator.cc
     TimeMaxEvaluator.cc
+    ExtractionEvaluator.cc
    )
 
 file(GLOB ats_generic_evals_inc_files "*.hh")

--- a/src/constitutive_relations/generic_evaluators/ExtractionEvaluator.cc
+++ b/src/constitutive_relations/generic_evaluators/ExtractionEvaluator.cc
@@ -1,0 +1,78 @@
+/* -*-  mode: c++; indent-tabs-mode: nil -*- */
+
+/*
+  Authors: Ethan Coon (ecoon@lanl.gov)
+*/
+/*!
+
+Extracts a field on one mesh from a field on a superset of that mesh using
+parent entities.
+
+*/
+
+#include "ExtractionEvaluator.hh"
+
+namespace Amanzi {
+namespace Relations {
+
+
+ExtractionEvaluator::ExtractionEvaluator(Teuchos::ParameterList& plist) :
+    EvaluatorSecondaryMonotypeCV(plist)
+{
+  Key my_key = my_keys_.front().first;
+  Tag tag = my_keys_.front().second;
+  parent_domain_ = Keys::readDomain(plist_, "parent");
+  dependency_key_ = Keys::readKey(plist_, parent_domain_, "extracted",
+          Keys::getVarName(my_key));
+  dependencies_.insert(KeyTag{dependency_key_, tag});
+}
+
+Teuchos::RCP<Evaluator>
+ExtractionEvaluator::Clone() const {
+  return Teuchos::rcp(new ExtractionEvaluator(*this));
+}
+
+// Required methods from EvaluatorSecondaryMonotype
+void
+ExtractionEvaluator::Evaluate_(const State& S,
+        const std::vector<CompositeVector*>& result)
+{
+  auto tag = my_keys_.front().second;
+  auto& parent_vector = S.Get<CompositeVector>(dependency_key_, tag);
+
+  for (const auto& comp : *result[0]) {
+    const Epetra_MultiVector& parent_vector_c = *parent_vector.ViewComponent(comp,false);
+    Epetra_MultiVector& result_c = *result[0]->ViewComponent(comp,false);
+
+    AmanziMesh::Entity_kind entity = result[0]->Location(comp);
+    auto mesh = result[0]->Mesh();
+
+    for (int j=0; j!=result_c.NumVectors(); ++j) {
+      for (int i=0; i!=result_c.MyLength(); ++i) {
+        result_c[j][i] = parent_vector_c[j][mesh->entity_get_parent(entity, i)];
+      }
+    }
+  }
+}
+
+
+void
+ExtractionEvaluator::EnsureCompatibility_ToDeps_(State& S)
+{
+  Key my_key = my_keys_.front().first;
+  Tag my_tag = my_keys_.front().second;
+  auto& my_fac = S.Require<CompositeVector,CompositeVectorSpace>(my_key, my_tag);
+
+  CompositeVectorSpace fac;
+  fac.SetMesh(S.GetMesh(parent_domain_));
+  for (auto& comp : my_fac) {
+    fac.AddComponent(comp, my_fac.Location(comp), my_fac.NumVectors(comp));
+  }
+  EvaluatorSecondaryMonotypeCV::EnsureCompatibility_ToDeps_(S, fac);
+}
+
+
+
+} //namespace
+} //namespace
+

--- a/src/constitutive_relations/generic_evaluators/ExtractionEvaluator.hh
+++ b/src/constitutive_relations/generic_evaluators/ExtractionEvaluator.hh
@@ -1,0 +1,51 @@
+/* -*-  mode: c++; indent-tabs-mode: nil -*- */
+
+/*
+  Authors: Ethan Coon (ecoon@lanl.gov)
+*/
+/*!
+
+Extracts a field on one mesh from a field on a superset of that mesh using
+parent entities.
+
+*/
+#pragma once
+
+#include "Factory.hh"
+
+#include "EvaluatorSecondaryMonotype.hh"
+
+namespace Amanzi {
+namespace Relations {
+
+class ExtractionEvaluator : public EvaluatorSecondaryMonotypeCV {
+
+ public:
+  explicit
+  ExtractionEvaluator(Teuchos::ParameterList& plist);
+  ExtractionEvaluator(const ExtractionEvaluator& other) = default;
+  virtual Teuchos::RCP<Evaluator> Clone() const override;
+
+ protected:
+  virtual void EnsureCompatibility_ToDeps_(State& S) override;
+
+  // Required methods from EvaluatorSecondaryMonotypeCV
+  virtual void Evaluate_(const State& S,
+          const std::vector<CompositeVector*>& result) override;
+  virtual void EvaluatePartialDerivative_(const State& S,
+          const Key& wrt_key, const Tag& wrt_tag, const std::vector<CompositeVector*>& result) override {
+    AMANZI_ASSERT(false);
+  }
+
+  Key dependency_key_;
+  Key parent_domain_;
+
+ private:
+  static Utils::RegisteredFactory<Evaluator,ExtractionEvaluator> reg_;
+
+};
+
+} //namespace
+} //namespace
+
+

--- a/src/constitutive_relations/generic_evaluators/ExtractionEvaluator_reg.hh
+++ b/src/constitutive_relations/generic_evaluators/ExtractionEvaluator_reg.hh
@@ -1,0 +1,23 @@
+/* -*-  mode: c++; indent-tabs-mode: nil -*- */
+
+/*
+  Authors: Ethan Coon (ecoon@lanl.gov)
+*/
+/*!
+
+Extracts a field on one mesh from a field on a superset of that mesh using
+parent entities.
+
+*/
+
+#include "ExtractionEvaluator.hh"
+
+namespace Amanzi {
+namespace Relations {
+
+// registry of method
+Utils::RegisteredFactory<Evaluator,ExtractionEvaluator> ExtractionEvaluator::reg_("extraction evaluator");
+
+} //namespace
+} //namespace
+


### PR DESCRIPTION
This adds a new evaluator that allows fields to be moved across parent mesh to derived mesh.

Examples of using this now include doing transport on the stream corridor while solving flow (to get stream corridor fluxes) on integrated hydrology.  