### PR TITLE
updates executables to work from jb/elm_api

### DIFF
--- a/src/executables/ats_driver.cc
+++ b/src/executables/ats_driver.cc
@@ -47,12 +47,6 @@ License: see ATS_DIR/COPYRIGHT
 
 namespace ATS {
 
-ATSDriver::ATSDriver(Teuchos::ParameterList& parameter_list,
-                     Amanzi::Comm_ptr_type comm)
-    : Coordinator(parameter_list, comm) {}
-
-
-
 // -----------------------------------------------------------------------------
 // setup and initialize, then run until time >= duration_
 // -----------------------------------------------------------------------------
@@ -153,7 +147,7 @@ void ATSDriver::cycle_driver() {
 // -----------------------------------------------------------------------------
 int ATSDriver::run()
 {
-  Amanzi::VerboseObject vo("ATS Driver", *parameter_list_);
+  Amanzi::VerboseObject vo("ATS Driver", *plist_);
   Teuchos::OSTab tab = vo.getOSTab();
 
   // print header material
@@ -161,7 +155,7 @@ int ATSDriver::run()
     // print parameter list
     *vo.os() << "======================> dumping parameter list <======================" <<
       std::endl;
-    Teuchos::writeParameterListToXmlOStream(*parameter_list_, *vo.os());
+    Teuchos::writeParameterListToXmlOStream(*plist_, *vo.os());
     *vo.os() << "======================> done dumping parameter list. <================" <<
       std::endl;
   }

--- a/src/executables/ats_driver.hh
+++ b/src/executables/ats_driver.hh
@@ -109,10 +109,7 @@ namespace ATS {
 class ATSDriver : public Coordinator {
 
 public:
-  ATSDriver(Teuchos::ParameterList& parameter_list,
-            Amanzi::Comm_ptr_type comm);
-
-  ~ATSDriver() = default;
+  using Coordinator::Coordinator;
 
   // methods
   void cycle_driver();

--- a/src/executables/coordinator.cc
+++ b/src/executables/coordinator.cc
@@ -47,44 +47,34 @@ actual work.
 
 #include "coordinator.hh"
 
-#define DEBUG_MODE 0
-
 namespace ATS {
 
-Coordinator::Coordinator(Teuchos::ParameterList& parameter_list,
-                         Amanzi::Comm_ptr_type comm ) :
-    parameter_list_(Teuchos::rcp(new Teuchos::ParameterList(parameter_list))),
+// this MUST be be called before using Coordinator
+Coordinator::Coordinator(const Teuchos::RCP<Teuchos::ParameterList>& plist,
+                         const Amanzi::Comm_ptr_type& comm)
+  : plist_(plist),
     comm_(comm),
-    restart_(false)
+    restart_(false),
+    timer_(Teuchos::rcp(new Teuchos::Time("wallclock_monitor",true))),
+    setup_timer_(Teuchos::TimeMonitor::getNewCounter("setup")),
+    cycle_timer_(Teuchos::TimeMonitor::getNewCounter("cycle"))
 {
-  // create and start the global timer
-  timer_ = Teuchos::rcp(new Teuchos::Time("wallclock_monitor",true));
-  setup_timer_ = Teuchos::TimeMonitor::getNewCounter("setup");
-  cycle_timer_ = Teuchos::TimeMonitor::getNewCounter("cycle");
-
   // create state.
-  S_ = Teuchos::rcp(new Amanzi::State(parameter_list_->sublist("state")));
+  S_ = Teuchos::rcp(new Amanzi::State(plist_->sublist("state")));
 
-  coordinator_init();
-
-  vo_ = Teuchos::rcp(new Amanzi::VerboseObject(comm, "Coordinator", *coordinator_list_));
-};
-
-void Coordinator::coordinator_init()
-{
   // create the geometric model and regions
-  Teuchos::ParameterList reg_list = parameter_list_->sublist("regions");
+  Teuchos::ParameterList reg_list = plist_->sublist("regions");
   Teuchos::RCP<Amanzi::AmanziGeometry::GeometricModel> gm =
     Teuchos::rcp(new Amanzi::AmanziGeometry::GeometricModel(3, reg_list, *comm_) );
 
   // create and register meshes
-  ATS::Mesh::createMeshes(*parameter_list_, comm_, gm, *S_);
+  ATS::Mesh::createMeshes(*plist_, comm_, gm, *S_);
 
-  coordinator_list_ = Teuchos::sublist(parameter_list_, "cycle driver");
-  read_parameter_list();
+  coordinator_list_ = Teuchos::sublist(plist_, "cycle driver");
+  InitializeFromPlist_();
 
   // create the top level PK
-  Teuchos::RCP<Teuchos::ParameterList> pks_list = Teuchos::sublist(parameter_list_, "PKs");
+  Teuchos::RCP<Teuchos::ParameterList> pks_list = Teuchos::sublist(plist_, "PKs");
   Teuchos::ParameterList pk_tree_list = coordinator_list_->sublist("PK tree");
   if (pk_tree_list.numParams() != 1) {
     Errors::Message message("CycleDriver: PK tree list should contain exactly one root node list");
@@ -98,14 +88,14 @@ void Coordinator::coordinator_init()
 
   // create the pk
   Amanzi::PKFactory pk_factory;
-  pk_ = pk_factory.CreatePK(pk_name, pk_tree_list, parameter_list_, S_, soln_);
+  pk_ = pk_factory.CreatePK(pk_name, pk_tree_list, plist_, S_, soln_);
 
   // create the checkpointing
-  Teuchos::ParameterList& chkp_plist = parameter_list_->sublist("checkpoint");
+  Teuchos::ParameterList& chkp_plist = plist_->sublist("checkpoint");
   checkpoint_ = Teuchos::rcp(new Amanzi::Checkpoint(chkp_plist, *S_));
 
   // create the observations
-  Teuchos::ParameterList& observation_plist = parameter_list_->sublist("observations");
+  Teuchos::ParameterList& observation_plist = plist_->sublist("observations");
   for (auto& sublist : observation_plist) {
     if (observation_plist.isSublist(sublist.first)) {
       observations_.emplace_back(Teuchos::rcp(new Amanzi::UnstructuredObservations(
@@ -128,13 +118,16 @@ void Coordinator::coordinator_init()
     }
 
     // writes region information
-    if (parameter_list_->isSublist("analysis")) {
+    if (plist_->isSublist("analysis")) {
       Amanzi::InputAnalysis analysis(mesh->second.first, mesh->first);
-      analysis.Init(parameter_list_->sublist("analysis").sublist(mesh->first));
+      analysis.Init(plist_->sublist("analysis").sublist(mesh->first));
       analysis.RegionAnalysis();
       analysis.OutputBCs();
     }
   }
+
+  // create verbose object
+  vo_ = Teuchos::rcp(new Amanzi::VerboseObject(comm_, "Coordinator", *coordinator_list_));
 
   // create the time step manager
   tsm_ = Teuchos::rcp(new Amanzi::TimeStepManager());
@@ -211,7 +204,7 @@ void Coordinator::initialize()
 
     for (Amanzi::State::mesh_iterator mesh=S_->mesh_begin();
          mesh!=S_->mesh_end(); ++mesh) {
-      if (S_->IsDeformableMesh(mesh->first) && !S_->IsAliasedMesh(mesh->first)) {
+      if (S_->IsDeformableMesh(mesh->first)) {
         Amanzi::DeformCheckpointMesh(*S_, mesh->first);
       }
     }
@@ -236,7 +229,7 @@ void Coordinator::initialize()
   WriteStateStatistics(*S_, *vo_);
 
   // Set up visualization
-  auto vis_list = Teuchos::sublist(parameter_list_,"visualization");
+  auto vis_list = Teuchos::sublist(plist_,"visualization");
   for (auto& entry : *vis_list) {
     std::string domain_name = entry.first;
 
@@ -244,9 +237,6 @@ void Coordinator::initialize()
       // visualize standard domain
       auto mesh_p = S_->GetMesh(domain_name);
       auto sublist_p = Teuchos::sublist(vis_list, domain_name);
-      if (S_->IsDeformableMesh(domain_name) && !sublist_p->isParameter("dynamic mesh"))
-        sublist_p->set("dynamic mesh", true);
-
       if (!sublist_p->isParameter("file name base")) {
         if (domain_name.empty() || domain_name == "domain") {
           sublist_p->set<std::string>("file name base", std::string("ats_vis"));
@@ -426,7 +416,7 @@ Coordinator::report_memory()
 
 
 void
-Coordinator::read_parameter_list()
+Coordinator::InitializeFromPlist_()
 {
   Amanzi::Utils::Units units;
   t0_ = coordinator_list_->get<double>("start time");

--- a/src/executables/coordinator.hh
+++ b/src/executables/coordinator.hh
@@ -37,24 +37,23 @@ class UnstructuredObservations;
 namespace ATS {
 
 class Coordinator {
-
-public:
-  Coordinator(Teuchos::ParameterList& parameter_list,
-              Amanzi::Comm_ptr_type comm);
+ public:
+  Coordinator(const Teuchos::RCP<Teuchos::ParameterList>& plist,
+              const Amanzi::Comm_ptr_type& comm);
 
   // PK methods
-  virtual void setup();
-  virtual void initialize();
-  virtual void finalize();
+  void setup();
+  void initialize();
+  void finalize();
   void report_memory();
+
   bool advance();
   void visualize(bool force=false);
   void checkpoint(bool force=false);
   double get_dt(bool after_fail=false);
 
  protected:
-  void coordinator_init();
-  void read_parameter_list();
+  void InitializeFromPlist_();
 
   // PK container and factory
   Teuchos::RCP<Amanzi::PK> pk_;
@@ -67,7 +66,7 @@ public:
   Teuchos::RCP<Amanzi::TimeStepManager> tsm_;
 
   // misc setup information
-  Teuchos::RCP<Teuchos::ParameterList> parameter_list_;
+  Teuchos::RCP<Teuchos::ParameterList> plist_;
   Teuchos::RCP<Teuchos::ParameterList> coordinator_list_;
 
   double t0_, t1_;

--- a/src/executables/main.cc
+++ b/src/executables/main.cc
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
     Amanzi::VerboseObject::global_default_level = opt_level;
 
   // create the top level driver and run simulation
-  ATS::ATSDriver driver(*plist, comm);
+  ATS::ATSDriver driver(plist, comm);
   int ret = 0;
   try {
     ret = driver.run();


### PR DESCRIPTION
This is work done by @jbeisman to refactor the coordinator and ats driver so that an external code (in this case ELM) could reuse most of the coordinator while driving the code.  It is useful to merge that code in now, even though the full ELM coupling is still a WIP, to avoid later conflicts and get those changes in this release.