### PR TITLE
fix broken registration includes

### DIFF
--- a/src/executables/ats_registration_files.hh
+++ b/src/executables/ats_registration_files.hh
@@ -20,8 +20,7 @@
 #include "ats_surface_balance_registration.hh"
 #include "ats_mpc_registration.hh"
 //#include "ats_sediment_transport_registration.hh"
-#include "mdm_transport_registration.hh"
-#include "multiscale_transport_registration.hh"
+#include "models_transport_reg.hh"
 #ifdef ALQUIMIA_ENABLED
-#  include "pks_chemistry_registration.hh"
+#include "pks_chemistry_reg.hh"
 #endif


### PR DESCRIPTION
This minor change fixes some registration includes in src/executables/ats_registration_files.hh that were broken by a recent reorganization of Amanzi's registration structure.   