### PR TITLE
tranport missing dag

### DIFF
--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -817,22 +817,28 @@ Transport_ATS::AdvanceStep(double t_old, double t_new, bool reinit)
                << " t1 = " << S_->get_time(tag_next_) << " h = " << dt_MPC << std::endl
                << "----------------------------------------------------------------" << std::endl;
 
-  S_->GetEvaluator(flux_key_, tag_next_).Update(*S_, name_);
+  // NOTE: these "flow" variables are hard-coded as Tag::NEXT assuming that
+  // flow is supercycled relative to transport and therefore we must
+  // interpolate the flow variables from the "global" CURRENT+NEXT to the
+  // subcycled current + next.  This would be fixed by having evaluators that
+  // interpolate in time, allowing transport to not have to know how flow is
+  // being integrated... FIXME --etc
+  S_->GetEvaluator(flux_key_, Tags::NEXT).Update(*S_, name_);
 
   // why are we re-assigning all of these?  The previous pointers shouldn't have changed... --ETC
-  flux_ = S_->Get<CompositeVector>(flux_key_, tag_next_).ViewComponent("face", true);
+  flux_ = S_->Get<CompositeVector>(flux_key_, Tags::NEXT).ViewComponent("face", true);
   // why are we copying this?  This should result in constant flux, no need to copy? --ETC
   *flux_copy_ = *flux_; // copy flux vector from S_next_ to S_;
 
-  S_->GetEvaluator(saturation_key_, tag_next_).Update(*S_, name_);
-  ws_ = S_->Get<CompositeVector>(saturation_key_, tag_next_).ViewComponent("cell", false);
-  S_->GetEvaluator(saturation_key_, tag_current_).Update(*S_, name_);
-  ws_prev_ = S_->Get<CompositeVector>(saturation_key_, tag_current_).ViewComponent("cell", false);
+  S_->GetEvaluator(saturation_key_, Tags::NEXT).Update(*S_, name_);
+  ws_ = S_->Get<CompositeVector>(saturation_key_, Tags::NEXT).ViewComponent("cell", false);
+  S_->GetEvaluator(saturation_key_, Tags::CURRENT).Update(*S_, name_);
+  ws_prev_ = S_->Get<CompositeVector>(saturation_key_, Tags::CURRENT).ViewComponent("cell", false);
 
-  S_->GetEvaluator(molar_density_key_, tag_next_).Update(*S_, name_);
-  mol_dens_ = S_->Get<CompositeVector>(molar_density_key_, tag_next_).ViewComponent("cell", false);
-  S_->GetEvaluator(molar_density_key_, tag_current_).Update(*S_, name_);
-  mol_dens_prev_ = S_->Get<CompositeVector>(molar_density_key_, tag_current_).ViewComponent("cell", false);
+  S_->GetEvaluator(molar_density_key_, Tags::NEXT).Update(*S_, name_);
+  mol_dens_ = S_->Get<CompositeVector>(molar_density_key_, Tags::NEXT).ViewComponent("cell", false);
+  S_->GetEvaluator(molar_density_key_, Tags::CURRENT).Update(*S_, name_);
+  mol_dens_prev_ = S_->Get<CompositeVector>(molar_density_key_, Tags::CURRENT).ViewComponent("cell", false);
 
   //if (subcycling_) S_->set_time(tag_subcycle_current_, t_old);
 
@@ -845,9 +851,10 @@ Transport_ATS::AdvanceStep(double t_old, double t_new, bool reinit)
   if (plist_->sublist("source terms").isSublist("geochemical")) {
     for (auto& src : srcs_) {
       if (src->name() == "alquimia source") {
-        // src_factor = water_source / molar_density_liquid
-        S_->GetEvaluator(geochem_src_factor_key_, tag_next_).Update(*S_, name_);
-        auto src_factor = S_->Get<CompositeVector>(geochem_src_factor_key_, tag_next_)
+        // src_factor = water_source / molar_density_liquid, both flow
+        // quantities, see note above.
+        S_->GetEvaluator(geochem_src_factor_key_, Tags::NEXT).Update(*S_, name_);
+        auto src_factor = S_->Get<CompositeVector>(geochem_src_factor_key_, Tags::NEXT)
                             .ViewComponent("cell", false);
         Teuchos::RCP<TransportSourceFunction_Alquimia_Units> src_alq =
           Teuchos::rcp_dynamic_cast<TransportSourceFunction_Alquimia_Units>(src);
@@ -893,6 +900,7 @@ Transport_ATS::AdvanceStep(double t_old, double t_new, bool reinit)
 
   double dt_sum = 0.0;
   double dt_cycle;
+  Tag water_tag_current, water_tag_next;
   if (interpolate_ws) {
     dt_cycle = std::min(dt_stable, dt_MPC);
     InterpolateCellVector(*ws_prev_, *ws_, dt_shift, dt_global, *ws_subcycle_current);
@@ -905,19 +913,23 @@ Transport_ATS::AdvanceStep(double t_old, double t_new, bool reinit)
     ws_next = ws_subcycle_next;
     mol_dens_current = mol_dens_subcycle_current;
     mol_dens_next = mol_dens_subcycle_next;
+    water_tag_current = tag_subcycle_current_;
+    water_tag_next = tag_subcycle_next_;
   } else {
     dt_cycle = dt_MPC;
     ws_current = ws_prev_;
     ws_next = ws_;
     mol_dens_current = mol_dens_prev_;
     mol_dens_next = mol_dens_;
+    water_tag_current = Tags::CURRENT;
+    water_tag_next = Tags::NEXT;
   }
 
-  db_->WriteVector("sat_old", S_->GetPtr<CompositeVector>(saturation_key_, tag_current_).ptr());
-  db_->WriteVector("sat_new", S_->GetPtr<CompositeVector>(saturation_key_, tag_next_).ptr());
-  db_->WriteVector("mol_dens_old", S_->GetPtr<CompositeVector>(molar_density_key_, tag_current_).ptr());
-  db_->WriteVector("mol_dens_new", S_->GetPtr<CompositeVector>(molar_density_key_, tag_next_).ptr());
-  db_->WriteVector("poro", S_->GetPtr<CompositeVector>(porosity_key_, tag_next_).ptr());
+  db_->WriteVector("sat_old", S_->GetPtr<CompositeVector>(saturation_key_, water_tag_current).ptr());
+  db_->WriteVector("sat_new", S_->GetPtr<CompositeVector>(saturation_key_, water_tag_next).ptr());
+  db_->WriteVector("mol_dens_old", S_->GetPtr<CompositeVector>(molar_density_key_, water_tag_current).ptr());
+  db_->WriteVector("mol_dens_new", S_->GetPtr<CompositeVector>(molar_density_key_, water_tag_next).ptr());
+  db_->WriteVector("poro", S_->GetPtr<CompositeVector>(porosity_key_, Tags::NEXT).ptr());
 
   for (int c = 0; c < ncells_owned; c++) {
     double vol_phi_ws_den;


### PR DESCRIPTION
Transport used values for saturation at the old and new times, but never Update()d the old time values.  This worked fine when those values were kept up to date by another PK, but broke when they were not (for instance, Phong found a case in extracting transport whereby the extraction evaluator was never called at the old tag).