### PR TITLE
Update ats-ci.yml to build images for arm64

### DIFF
--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -61,7 +61,7 @@ jobs:
         username: ${{secrets.DOCKERHUB_USERNAME}}
         password: ${{secrets.DOCKERHUB_PASSWORD}}
     - name: Build and push multiarch image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       with:
         tags: metsi/ats:${{env.ATS_BRANCH_TAG}}-latest
         platforms: linux/amd64,linux/arm64
@@ -71,6 +71,7 @@ jobs:
           ats_branch=${{env.ATS_BRANCH}}
           amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
         file: Docker/Dockerfile-ATS-build
+        context: ./Docker
     - name: Run tests
       id: tests
       working-directory: Docker

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -72,9 +72,14 @@ jobs:
           amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
         file: Docker/Dockerfile-ATS-build
         context: ./Docker
-    - name: Run tests
-      id: tests
+    - name: Run amd64 tests
+      id: tests_amd64
       working-directory: Docker
       run:
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
+    - name: Run arm64 tests
+      id: tests_arm64
+      working-directory: Docker
+      run:
+        docker run --platform=linux/arm64 --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
         

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{secrets.DOCKERHUB_USERNAME}}
         password: ${{secrets.DOCKERHUB_PASSWORD}}
@@ -70,7 +70,7 @@ jobs:
           amanzi_branch=${{env.AMANZI_BRANCH}}
           ats_branch=${{env.ATS_BRANCH}}
           amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
-        file: Dockerfile-ATS-build
+        file: Docker/Dockerfile-ATS-build
     - name: Run tests
       id: tests
       working-directory: Docker

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -11,12 +11,12 @@ on:
       - ats-*
 
 jobs:
-  build_test:
+  buildx_test:
     runs-on: ubuntu-latest
     name: Build and test with Docker
     steps:
     - name: Check out the Amanzi repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: amanzi/amanzi
         ref: master
@@ -51,20 +51,26 @@ jobs:
         echo "ats-regression-tests branch = ${{env.ATS_TESTS_BRANCH}}";
         echo "Tag reference = ${{env.ATS_BRANCH_TAG}}"
         echo "TPLs version = ${{env.AMANZI_TPLS_VER}}"
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
         username: ${{secrets.DOCKERHUB_USERNAME}}
         password: ${{secrets.DOCKERHUB_PASSWORD}}
-    - name: Docker build
-      id: docker
-      working-directory: Docker
-      run:
-        docker build --build-arg amanzi_branch=${{env.AMANZI_BRANCH}} --build-arg ats_branch=${{env.ATS_BRANCH}} --build-arg ats_tests_branch=${{env.ATS_TESTS_BRANCH}} --build-arg amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}} -t metsi/ats:${{env.ATS_BRANCH_TAG}}-latest -f Dockerfile-ATS-build .      
-    - name: Docker push
-      working-directory: Docker
-      run:
-        docker push ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest
+    - name: Build and push multiarch image
+      uses: docker/build-push-action@v3
+      with:
+        tags: metsi/ats:${{env.ATS_BRANCH_TAG}}-latest
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: |
+          amanzi_branch=${{env.AMANZI_BRANCH}}
+          ats_branch=${{env.ATS_BRANCH}}
+          amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
+        file: Dockerfile-ATS-build
     - name: Run tests
       id: tests
       working-directory: Docker

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -89,7 +89,6 @@ jobs:
           echo "ATS_BRANCH_TAG=$(echo ${{env.ATS_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
       - name: Run amd64 tests
         id: tests_amd64
-        working-directory: Docker
         run:
           docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
   arm64_tests:
@@ -101,7 +100,6 @@ jobs:
         uses: actions/checkout@v3    
       - name: Extract the ATS branch name
         id: branch
-        working-directory: Docker
         run: |
           echo "ATS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
       - name: Filter the branch name to generate a tag for Docker
@@ -110,7 +108,6 @@ jobs:
           echo "ATS_BRANCH_TAG=$(echo ${{env.ATS_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
       - name: Run arm64 tests
         id: tests_arm64
-        working-directory: Docker
         run:
           docker run --platform=linux/arm64 --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
         

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -77,9 +77,9 @@ jobs:
     name: Run ats tests on amd64 image
     needs: buildx_test
     steps:
-      - name: Check out the Amanzi repo
+      - name: Check out the ats repo
         uses: actions/checkout@v3
-      -  name: Extract the branch name
+      - name: Extract the branch name
         id: branch
         run:
           echo "ATS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
@@ -97,11 +97,12 @@ jobs:
     name: Run ats tests on arm64 image
     needs: buildx_test
     steps: 
-      - name: Check out the Amanzi repo
-        uses: actions/checkout@v3
-      -  name: Extract the branch name
+      - name: Check out the ats repo
+        uses: actions/checkout@v3    
+      - name: Extract the ATS branch name
         id: branch
-        run:
+        working-directory: Docker
+        run: |
           echo "ATS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
       - name: Filter the branch name to generate a tag for Docker
         id: tag

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -72,14 +72,24 @@ jobs:
           amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
         file: Docker/Dockerfile-ATS-build
         context: ./Docker
-    - name: Run amd64 tests
-      id: tests_amd64
-      working-directory: Docker
-      run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
-    - name: Run arm64 tests
-      id: tests_arm64
-      working-directory: Docker
-      run:
-        docker run --platform=linux/arm64 --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
+  amd64_tests:
+    runs-on: ubuntu-latest
+    name: Run ats tests on amd64 image
+    needs: buildx_test
+    steps:
+      - name: Run amd64 tests
+        id: tests_amd64
+        working-directory: Docker
+        run:
+          docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
+  arm64_tests:
+    runs-on: ubuntu-latest
+    name: Run ats tests on arm64 image
+    needs: buildx_test
+    steps: 
+      - name: Run arm64 tests
+        id: tests_arm64
+        working-directory: Docker
+        run:
+          docker run --platform=linux/arm64 --rm ${{secrets.DOCKERHUB_USERNAME}}/ats:${{env.ATS_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/ats; ctest"
         

--- a/.github/workflows/ats-ci.yml
+++ b/.github/workflows/ats-ci.yml
@@ -77,6 +77,16 @@ jobs:
     name: Run ats tests on amd64 image
     needs: buildx_test
     steps:
+      - name: Check out the Amanzi repo
+        uses: actions/checkout@v3
+      -  name: Extract the branch name
+        id: branch
+        run:
+          echo "ATS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+      - name: Filter the branch name to generate a tag for Docker
+        id: tag
+        run:
+          echo "ATS_BRANCH_TAG=$(echo ${{env.ATS_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
       - name: Run amd64 tests
         id: tests_amd64
         working-directory: Docker
@@ -87,6 +97,16 @@ jobs:
     name: Run ats tests on arm64 image
     needs: buildx_test
     steps: 
+      - name: Check out the Amanzi repo
+        uses: actions/checkout@v3
+      -  name: Extract the branch name
+        id: branch
+        run:
+          echo "ATS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+      - name: Filter the branch name to generate a tag for Docker
+        id: tag
+        run:
+          echo "ATS_BRANCH_TAG=$(echo ${{env.ATS_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
       - name: Run arm64 tests
         id: tests_arm64
         working-directory: Docker


### PR DESCRIPTION
Updates the ats-ci.yml GitHub action to build images for both amd64 and arm64 using buildx. It is built on the TPLs image, which is currently only amd64 and will need to be updated as well.

Currently only runs the tests on the amd64 image. I think the CI action could be modified to run on both architectures - let me know if this would be preferred and I'll update the PR. 

One of the regression tests fails on a local test of the arm64 image, but this was due to the timeout threshold being too low. I suspect that this issue will go away when the TPL image is also built for arm64.