### PR TITLE
Fixes time stepping bug in coupled reactive transport and catches alquimia pk fail exception 

### DIFF
--- a/src/pks/mpc/mpc_coupled_reactivetransport.cc
+++ b/src/pks/mpc/mpc_coupled_reactivetransport.cc
@@ -173,7 +173,10 @@ MPCCoupledReactiveTransport::get_dt()
   double dTchem = coupled_chemistry_pk_->get_dt();
 
   if (!chem_step_succeeded_ && (dTchem / dTtran > 0.99)) { dTchem *= 0.5; }
-  return dTchem;
+
+  if (dTtran > dTchem) dTtran= dTchem;
+
+  return dTtran;
 }
 
 
@@ -218,8 +221,12 @@ MPCCoupledReactiveTransport::AdvanceStep(double t_old, double t_new, bool reinit
   S_->GetEvaluator(mol_dens_key_, tag_next_).Update(*S_, name_);
   Teuchos::RCP<const Epetra_MultiVector> mol_dens =
     S_->Get<CompositeVector>(mol_dens_key_, tag_next_).ViewComponent("cell", true);
-  fail = advanceChemistry(chemistry_pk_, t_old, t_new, reinit, *mol_dens, tcc, *alquimia_timer_);
-  changedEvaluatorPrimary(tcc_key_, tag_next_, *S_);
+  try {
+    fail = advanceChemistry(chemistry_pk_, t_old, t_new, reinit, *mol_dens, tcc, *alquimia_timer_);
+    changedEvaluatorPrimary(tcc_key_, tag_next_, *S_);
+  } catch (const Errors::Message& chem_error) {
+    fail = true;
+  }
   if (fail) {
     if (vo_->os_OK(Teuchos::VERB_MEDIUM))
       *vo_->os() << chemistry_pk_->name() << " failed." << std::endl;

--- a/src/pks/mpc/mpc_coupled_reactivetransport.cc
+++ b/src/pks/mpc/mpc_coupled_reactivetransport.cc
@@ -174,7 +174,7 @@ MPCCoupledReactiveTransport::get_dt()
 
   if (!chem_step_succeeded_ && (dTchem / dTtran > 0.99)) { dTchem *= 0.5; }
 
-  if (dTtran > dTchem) dTtran= dTchem;
+  if (dTtran > dTchem) dTtran = dTchem;
 
   return dTtran;
 }


### PR DESCRIPTION
Time step for coupled reactive transport needs to be the minimum of both transport and chemistry pk time step. 
Alquimia PK Chemistry can (and will) fail so we need to catch it such that time step is adjusted accordingly.  
(Replacing Alquimia PK  ComputeNextTimeStep with a TimestepController-class-based time stepping for non linear solvers is not part of this pull request. It will be done in Amanzi but is not required for this to work.)