### PR TITLE
Rename subcycling

### DIFF
--- a/src/pks/mpc/mpc_weak_subdomain.cc
+++ b/src/pks/mpc/mpc_weak_subdomain.cc
@@ -269,15 +269,13 @@ MPCWeakSubdomain::CommitStep(double t_old, double t_new, const Tag& tag_next)
     }
   }
 
-  if (tag_next == tag_next_ && tag_next != Tags::NEXT && internal_subcycling_) {
-    // nested subcycling -- we are internally subcycling and something above
-    // us in the PK tree is trying to subcycle this.  Currently the tags
-    // model does not admit this.
-    Errors::Message msg;
-    msg << "MPCWeakSubdomain \"" << name_ << "\" detected nested subcycling, which is not currently supported.  Either subcycle the subdomains independently or subcycle the MPCWeakSubdomain, but not both.";
-    Exceptions::amanzi_throw(msg);
+  if (tag_next == tag_next_ && tag_next != Tags::NEXT) {
+    // do not commit step in this case -- this is nested subcycling, which we
+    // do not have a formal way of dealing with correctly.
+    return;
+  } else {
+    for (const auto& pk : sub_pks_) { pk->CommitStep(t_old, t_new, tag_next); }
   }
-  for (const auto& pk : sub_pks_) { pk->CommitStep(t_old, t_new, tag_next); }
 }
 
 

--- a/src/pks/mpc/mpc_weak_subdomain.cc
+++ b/src/pks/mpc/mpc_weak_subdomain.cc
@@ -38,9 +38,9 @@ MPCWeakSubdomain::MPCWeakSubdomain(Teuchos::ParameterList& FElist,
   init_();
 
   // check whether we are subcycling
-  subcycled_ = plist_->template get<bool>("subcycle", false);
-  if (subcycled_) {
-    subcycled_target_dt_ = plist_->template get<double>("subcycling target time step [s]");
+  internal_subcycling_ = plist_->template get<bool>("subcycle", false);
+  if (internal_subcycling_) {
+    internal_subcycling_target_dt_ = plist_->template get<double>("subcycling target time step [s]");
   }
 };
 
@@ -53,8 +53,8 @@ MPCWeakSubdomain::get_dt()
 {
   double dt = std::numeric_limits<double>::max();
 
-  if (subcycled_) {
-    dt = subcycled_target_dt_;
+  if (internal_subcycling_) {
+    dt = internal_subcycling_target_dt_;
   } else {
     for (auto& pk : sub_pks_) dt = std::min(dt, pk->get_dt());
     double dt_local = dt;
@@ -69,7 +69,7 @@ MPCWeakSubdomain::get_dt()
 void
 MPCWeakSubdomain::set_dt(double dt)
 {
-  if (subcycled_) {
+  if (internal_subcycling_) {
     cycle_dt_ = dt;
   } else {
     for (auto& pk : sub_pks_) pk->set_dt(dt);
@@ -83,7 +83,7 @@ MPCWeakSubdomain::set_dt(double dt)
 void
 MPCWeakSubdomain::set_tags(const Tag& current, const Tag& next)
 {
-  if (subcycled_) {
+  if (internal_subcycling_) {
     PK::set_tags(current, next);
 
     const auto& ds = S_->GetDomainSet(ds_name_);
@@ -104,7 +104,7 @@ MPCWeakSubdomain::set_tags(const Tag& current, const Tag& next)
 void
 MPCWeakSubdomain::Setup()
 {
-  if (subcycled_) {
+  if (internal_subcycling_) {
     const auto& ds = S_->GetDomainSet(ds_name_);
     for (const auto& subdomain : *ds) {
       Tag tag_subcycle_current = get_ds_tag_current_(subdomain);
@@ -123,7 +123,7 @@ MPCWeakSubdomain::Setup()
 void
 MPCWeakSubdomain::Initialize()
 {
-  if (subcycled_) {
+  if (internal_subcycling_) {
     const auto& ds = S_->GetDomainSet(ds_name_);
     for (const auto& subdomain : *ds) {
       Tag tag_subcycle_next = get_ds_tag_next_(subdomain);
@@ -140,8 +140,8 @@ MPCWeakSubdomain::Initialize()
 bool
 MPCWeakSubdomain::AdvanceStep(double t_old, double t_new, bool reinit)
 {
-  if (subcycled_)
-    return AdvanceStep_Subcycled_(t_old, t_new, reinit);
+  if (internal_subcycling_)
+    return AdvanceStep_InternalSubcycling_(t_old, t_new, reinit);
   else
     return AdvanceStep_Standard_(t_old, t_new, reinit);
 }
@@ -169,7 +169,7 @@ MPCWeakSubdomain::AdvanceStep_Standard_(double t_old, double t_new, bool reinit)
 // Advance the timestep through subcyling
 //-------------------------------------------------------------------------------------
 bool
-MPCWeakSubdomain::AdvanceStep_Subcycled_(double t_old, double t_new, bool reinit)
+MPCWeakSubdomain::AdvanceStep_InternalSubcycling_(double t_old, double t_new, bool reinit)
 {
   Teuchos::OSTab tab = vo_->getOSTab();
   bool fail = false;
@@ -258,7 +258,7 @@ MPCWeakSubdomain::CommitStep(double t_old, double t_new, const Tag& tag_next)
 {
   if (S_->get_cycle() < 0 && tag_next == Tags::NEXT) {
     // initial commit, also do the substep commits
-    if (subcycled_) {
+    if (internal_subcycling_) {
       const auto& ds = S_->GetDomainSet(ds_name_);
       int i = 0;
       for (auto& domain : *ds) {
@@ -269,13 +269,15 @@ MPCWeakSubdomain::CommitStep(double t_old, double t_new, const Tag& tag_next)
     }
   }
 
-  if (tag_next == tag_next_ && tag_next != Tags::NEXT) {
-    // do not commit step in this case -- this is nested subcycling, which we
-    // do not have a formal way of dealing with correctly.
-    return;
-  } else {
-    for (const auto& pk : sub_pks_) { pk->CommitStep(t_old, t_new, tag_next); }
+  if (tag_next == tag_next_ && tag_next != Tags::NEXT && internal_subcycling_) {
+    // nested subcycling -- we are internally subcycling and something above
+    // us in the PK tree is trying to subcycle this.  Currently the tags
+    // model does not admit this.
+    Errors::Message msg;
+    msg << "MPCWeakSubdomain \"" << name_ << "\" detected nested subcycling, which is not currently supported.  Either subcycle the subdomains independently or subcycle the MPCWeakSubdomain, but not both.";
+    Exceptions::amanzi_throw(msg);
   }
+  for (const auto& pk : sub_pks_) { pk->CommitStep(t_old, t_new, tag_next); }
 }
 
 

--- a/src/pks/mpc/mpc_weak_subdomain.hh
+++ b/src/pks/mpc/mpc_weak_subdomain.hh
@@ -45,26 +45,26 @@ class MPCWeakSubdomain : public MPC<PK> {
   void init_();
 
   bool AdvanceStep_Standard_(double t_old, double t_new, bool reinit);
-  bool AdvanceStep_Subcycled_(double t_old, double t_new, bool reinit);
+  bool AdvanceStep_InternalSubcycling_(double t_old, double t_new, bool reinit);
 
   Tag get_ds_tag_next_(const std::string& subdomain)
   {
-    if (subcycled_)
+    if (internal_subcycling_)
       return Tag(Keys::getKey(subdomain, tag_next_.get()));
     else
       return tag_next_;
   }
   Tag get_ds_tag_current_(const std::string& subdomain)
   {
-    if (subcycled_)
+    if (internal_subcycling_)
       return Tag(Keys::getKey(subdomain, tag_current_.get()));
     else
       return tag_current_;
   }
 
   Comm_ptr_type comm_;
-  bool subcycled_;
-  double subcycled_target_dt_;
+  bool internal_subcycling_;
+  double internal_subcycling_target_dt_;
   double cycle_dt_;
   Key ds_name_;
 


### PR DESCRIPTION
This pull request aims to rename the 'internal_subcycling_' feature, which is currently unsupported in the MPC weak domain, in order to distinguish it from 'external_subcycling_' (which is supported).