### PR TITLE
CommitStep bug fix in weak domain transport

### DIFF
--- a/src/pks/mpc/mpc_weak_subdomain.cc
+++ b/src/pks/mpc/mpc_weak_subdomain.cc
@@ -269,13 +269,15 @@ MPCWeakSubdomain::CommitStep(double t_old, double t_new, const Tag& tag_next)
     }
   }
 
-  if (tag_next == tag_next_ && tag_next != Tags::NEXT) {
-    // do not commit step in this case -- this is nested subcycling, which we
-    // do not have a formal way of dealing with correctly.
-    return;
-  } else {
-    for (const auto& pk : sub_pks_) { pk->CommitStep(t_old, t_new, tag_next); }
+  if (tag_next == tag_next_ && tag_next != Tags::NEXT && subcycled_) {
+    // nested subcycling -- we are internally subcycling and something above
+    // us in the PK tree is trying to subcycle this.  Currently the tags
+    // model does not admit this.
+    Errors::Message msg;
+    msg << "MPCWeakSubdomain \"" << name_ << "\" detected nested subcycling, which is not currently supported.  Either subcycle the subdomains independently or subcycle the MPCWeakSubdomain, but not both.";
+    Exceptions::amanzi_throw(msg);
   }
+  for (const auto& pk : sub_pks_) { pk->CommitStep(t_old, t_new, tag_next); }
 }
 
 


### PR DESCRIPTION
This PR fixes a bug in the CommitStep() function within the weak domain MPC in the transport component. The bug currently prevents the subgrid model from advancing correctly during the CommitStep().

Changes Made:

1. Introduced an internal flag, named subcycled_, within the IF condition. 
2. In the PR #219, this flag has been renamed to internal_subcycling_ for better clarity.
