### PR TITLE
Reorganizing Transport_ATS::Setup()

### DIFF
--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -390,7 +390,9 @@ class Transport_ATS : public PK_PhysicalExplicit<Epetra_Vector> {
 
  private:
   void InitializeFields_();
-
+  void SetupTransport_();
+  void SetupPhysicalEvaluators_();
+  
   // advection members
   void AdvanceDonorUpwind(double dT);
   void AdvanceSecondOrderUpwindRKn(double dT);

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -418,6 +418,9 @@ Transport_ATS::Initialize()
   flux_copy_->PutScalar(0.);
 
   phi_ = S_->Get<CompositeVector>(porosity_key_, Tags::NEXT).ViewComponent("cell", false);
+  
+  // this is locally created and has no evaluator -- should get a primary
+  // variable FE owned by this PK --ETC
   solid_qty_ = S_->GetW<CompositeVector>(solid_residue_mass_key_, tag_next_, name_)
                  .ViewComponent("cell", false);
   conserve_qty_ =
@@ -887,11 +890,6 @@ Transport_ATS::AdvanceStep(double t_old, double t_new, bool reinit)
   S_->GetEvaluator(molar_density_key_, Tags::CURRENT).Update(*S_, name_);
 
   //if (subcycling_) S_->set_time(tag_subcycle_current_, t_old);
-
-  // this is locally created and has no evaluator -- should get a primary
-  // variable FE owned by this PK --ETC
-  // solid_qty_ = S_->GetW<CompositeVector>(solid_residue_mass_key_, tag_next_, name_)
-  //                .ViewComponent("cell", false);
 
   // We use original tcc and make a copy of it later if needed.
   tcc = S_->GetPtrW<CompositeVector>(tcc_key_, tag_current_, passwd_);


### PR DESCRIPTION
This pull request aims to reorganize the transport PK to align its structure with that of the flow PKs. The primary change involves breaking down the original Transport::Setup function into two separate functions: SetupTransport_() and SetupPhysicalEvaluators_().

The motivation behind this PR is to prepare the transport PK for an upcoming refactor. This refactor will introduce a new evaluator for flow interpolation outside the Transport::AdvanceStep(), enhancing the overall performance and accuracy.