### PR TITLE
Move source terms in TransportPK from Initialize() to Setup()

### DIFF
--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -390,6 +390,8 @@ class Transport_ATS : public PK_PhysicalExplicit<Epetra_Vector> {
 
  private:
   void InitializeFields_();
+  void SetupTransport_();
+  void SetupPhysicalEvaluators_();
 
   // advection members
   void AdvanceDonorUpwind(double dT);


### PR DESCRIPTION
This PR (1) re-organizes transport and (2) move source term from Initialize() to Setup() in TransportPK.