### PR TITLE
Attempt to fix a bug in transport PK for SWI case. 

### DIFF
--- a/src/constitutive_relations/eos/eos_evaluator.cc
+++ b/src/constitutive_relations/eos/eos_evaluator.cc
@@ -88,8 +88,8 @@ EOSEvaluator::ParsePlistTemp_()
   Tag tag = my_keys_.front().second;
 
   // -- temperature
-  temp_key_ = Keys::readKey(plist_, domain_name, "temperature", "temperature");
-  dependencies_.insert(KeyTag{ temp_key_, tag });
+  temp_key_ = Keys::readKeyTag(plist_, domain_name, "temperature", "temperature", tag);
+  dependencies_.insert(temp_key_);
 }
 
 
@@ -100,8 +100,8 @@ EOSEvaluator::ParsePlistPres_()
   Tag tag = my_keys_.front().second;
 
   // -- pressure
-  pres_key_ = Keys::readKey(plist_, domain_name, "pressure", "pressure");
-  dependencies_.insert(KeyTag{ pres_key_, tag });
+  pres_key_ = Keys::readKeyTag(plist_, domain_name, "pressure", "pressure", tag);
+  dependencies_.insert(pres_key_);
 }
 
 
@@ -112,8 +112,8 @@ EOSEvaluator::ParsePlistConc_()
   Tag tag = my_keys_.front().second;
 
   // -- concentration
-  conc_key_ = Keys::readKey(plist_, domain_name, "concentration", "total_component_concentration");
-  dependencies_.insert(KeyTag{ conc_key_, tag });
+  conc_key_ = Keys::readKeyTag(plist_, domain_name, "concentration", "total_component_concentration", tag);
+  dependencies_.insert(conc_key_);
 }
 
 
@@ -156,9 +156,9 @@ EOSEvaluator::Evaluate_(const State& S, const std::vector<CompositeVector*>& res
 
   // Pull dependencies out of state.
   auto tag = my_keys_.front().second;
-  if (eos_->IsConcentration()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(conc_key_, tag).get());
-  if (eos_->IsTemperature()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(temp_key_, tag).get());
-  if (eos_->IsPressure()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(pres_key_, tag).get());
+  if (eos_->IsConcentration()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(conc_key_.first, conc_key_.second).get());
+  if (eos_->IsTemperature()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(temp_key_.first, temp_key_.second).get());
+  if (eos_->IsPressure()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(pres_key_.first, pres_key_.second).get());
 
   CompositeVector* molar_dens(nullptr);
   CompositeVector* mass_dens(nullptr);
@@ -241,12 +241,13 @@ EOSEvaluator::EvaluatePartialDerivative_(const State& S,
   std::vector<double> eos_params(num_dep);
   std::vector<const CompositeVector*> dep_cv;
   std::vector<const Epetra_MultiVector*> dep_vec(num_dep, nullptr);
+  KeyTag wrt{wrt_key, wrt_tag};
 
   // Pull dependencies out of state.
   auto tag = my_keys_.front().second;
-  if (eos_->IsConcentration()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(conc_key_, tag).get());
-  if (eos_->IsTemperature()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(temp_key_, tag).get());
-  if (eos_->IsPressure()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(pres_key_, tag).get());
+  if (eos_->IsConcentration()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(conc_key_.first, conc_key_.second).get());
+  if (eos_->IsTemperature()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(temp_key_.first, temp_key_.second).get());
+  if (eos_->IsPressure()) dep_cv.emplace_back(S.GetPtr<CompositeVector>(pres_key_.first, pres_key_.second).get());
 
   CompositeVector* molar_dens(nullptr);
   CompositeVector* mass_dens(nullptr);
@@ -270,17 +271,17 @@ EOSEvaluator::EvaluatePartialDerivative_(const State& S,
       auto& dens_v = *(molar_dens->ViewComponent(*comp, false));
       int count = dens_v.MyLength();
 
-      if (wrt_key == conc_key_) {
+      if (wrt == conc_key_) {
         for (int id = 0; id != count; ++id) {
           for (int k = 0; k < num_dep; k++) { eos_params[k] = (*dep_vec[k])[0][id]; }
           dens_v[0][id] = eos_->DMolarDensityDC(eos_params);
         }
-      } else if (wrt_key == pres_key_) {
+      } else if (wrt == pres_key_) {
         for (int id = 0; id != count; ++id) {
           for (int k = 0; k < num_dep; k++) { eos_params[k] = (*dep_vec[k])[0][id]; }
           dens_v[0][id] = eos_->DMolarDensityDp(eos_params);
         }
-      } else if (wrt_key == temp_key_) {
+      } else if (wrt == temp_key_) {
         for (int id = 0; id != count; ++id) {
           for (int k = 0; k < num_dep; k++) { eos_params[k] = (*dep_vec[k])[0][id]; }
           dens_v[0][id] = eos_->DMolarDensityDT(eos_params);
@@ -309,17 +310,17 @@ EOSEvaluator::EvaluatePartialDerivative_(const State& S,
         auto& dens_v = *(mass_dens->ViewComponent(*comp, false));
         int count = dens_v.MyLength();
 
-        if (wrt_key == conc_key_) {
+        if (wrt == conc_key_) {
           for (int id = 0; id != count; ++id) {
             for (int k = 0; k < num_dep; k++) eos_params[k] = (*dep_vec[k])[0][id];
             dens_v[0][id] = eos_->DMassDensityDC(eos_params);
           }
-        } else if (wrt_key == pres_key_) {
+        } else if (wrt == pres_key_) {
           for (int id = 0; id != count; ++id) {
             for (int k = 0; k < num_dep; k++) eos_params[k] = (*dep_vec[k])[0][id];
             dens_v[0][id] = eos_->DMassDensityDp(eos_params);
           }
-        } else if (wrt_key == temp_key_) {
+        } else if (wrt == temp_key_) {
           for (int id = 0; id != count; ++id) {
             for (int k = 0; k < num_dep; k++) eos_params[k] = (*dep_vec[k])[0][id];
             dens_v[0][id] = eos_->DMassDensityDT(eos_params);

--- a/src/constitutive_relations/eos/eos_evaluator.hh
+++ b/src/constitutive_relations/eos/eos_evaluator.hh
@@ -54,7 +54,7 @@ class EOSEvaluator : public EvaluatorSecondaryMonotypeCV {
   // the actual model
   Teuchos::RCP<EOS> eos_;
 
-  Key temp_key_, pres_key_, conc_key_;
+  KeyTag temp_key_, pres_key_, conc_key_;
   EOSMode mode_;
   bool updated_once_;
 

--- a/src/pks/flow/constitutive_relations/overland_conductivity/one_uf_relperm_model.cc
+++ b/src/pks/flow/constitutive_relations/overland_conductivity/one_uf_relperm_model.cc
@@ -21,8 +21,7 @@
 namespace Amanzi {
 namespace Flow {
 
-OneUFRelPermModel::OneUFRelPermModel(Teuchos::ParameterList& plist)
-  : plist_(plist), pi_(M_PI)
+OneUFRelPermModel::OneUFRelPermModel(Teuchos::ParameterList& plist) : plist_(plist), pi_(M_PI)
 {
   alpha_ = plist_.get<int>("unfrozen rel perm alpha", 4);
   if (alpha_ % 2 != 0) {

--- a/src/pks/flow/constitutive_relations/overland_conductivity/zero_uf_relperm_model.cc
+++ b/src/pks/flow/constitutive_relations/overland_conductivity/zero_uf_relperm_model.cc
@@ -21,8 +21,7 @@
 namespace Amanzi {
 namespace Flow {
 
-ZeroUFRelPermModel::ZeroUFRelPermModel(Teuchos::ParameterList& plist)
-  : plist_(plist), pi_(M_PI)
+ZeroUFRelPermModel::ZeroUFRelPermModel(Teuchos::ParameterList& plist) : plist_(plist), pi_(M_PI)
 {
   alpha_ = plist_.get<int>("unfrozen rel perm alpha", 4);
   if (alpha_ % 2 != 0) {

--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -388,6 +388,8 @@ class Transport_ATS : public PK_PhysicalExplicit<Epetra_Vector> {
   int get_num_gaseous_component() { return num_gaseous; };
 
 
+  void ChangedSolutionPK(const Tag& tag);
+
  private:
   void InitializeFields_();
 


### PR DESCRIPTION
Attempt to fix a bug in transport PK for SWI case. 
Molar density, which depends on concentration, was not updated properly.
When molar density updated is requested at the begging of AdvanceStep concentration are not marked as changes so the update is not actually triggered. I don't know is it an issue with assign function or tags.
Therefore I've enforced update of molar density in Commit function, although I suspect it is not the optimal solution.
