### PR TITLE
Fixing misses of input converters

### DIFF
--- a/src/pks/flow/constitutive_relations/sources/soil_resistance_sakagucki_zeng_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/sources/soil_resistance_sakagucki_zeng_evaluator.hh
@@ -48,7 +48,7 @@ Example:
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />

--- a/src/pks/flow/constitutive_relations/sources/soil_resistance_sakagucki_zeng_model.hh
+++ b/src/pks/flow/constitutive_relations/sources/soil_resistance_sakagucki_zeng_model.hh
@@ -69,7 +69,7 @@ class SoilResistanceSakaguckiZengModel {
     d_ = plist_.get<double>("dessicated zone thickness [m]", 0.1);
     sr_ = plist_.get<double>("residual saturation [-]", 0.0);
 
-    if (plist_.get<std::string>("WRM Type") == "van Genuchten") {
+    if (plist_.get<std::string>("wrm type") == "van Genuchten") {
       if (plist_.isParameter("van Genuchten m [-]")) {
         double m = plist_.get<double>("van Genuchten m [-]");
         double n = 1.0 / (1.0 - m);
@@ -80,7 +80,7 @@ class SoilResistanceSakaguckiZengModel {
         double lambda = (n - 1) * (1 - std::pow(0.5, n / (n - 1)));
         b_ = 1. / lambda;
       }
-    } else if (plist_.get<std::string>("WRM Type") == "Brooks-Corey") {
+    } else if (plist_.get<std::string>("wrm type") == "Brooks-Corey") {
       double lambda = plist_.get<double>("Brooks Corey lambda [-]");
       b_ = 1. / lambda;
     } else {

--- a/src/pks/flow/constitutive_relations/sources/soil_resistance_sellers_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/sources/soil_resistance_sellers_evaluator.hh
@@ -30,7 +30,7 @@ Example:
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />

--- a/src/pks/flow/constitutive_relations/wrm/models/test/plot_wrm.cc
+++ b/src/pks/flow/constitutive_relations/wrm/models/test/plot_wrm.cc
@@ -62,19 +62,19 @@ main(int argc, char* argv[])
   }
 
   std::stringstream filename_s_stream;
-  filename_s_stream << plist.get<std::string>("WRM Type") << "_sat.txt";
+  filename_s_stream << plist.get<std::string>("wrm type") << "_sat.txt";
   std::string filename_s(filename_s_stream.str());
   for (int j = 0; j != filename_s.length(); ++j)
     if (filename_s[j] == ' ') filename_s[j] = '_';
 
   std::stringstream filename_pc_stream;
-  filename_pc_stream << plist.get<std::string>("WRM Type") << "_pc.txt";
+  filename_pc_stream << plist.get<std::string>("wrm type") << "_pc.txt";
   std::string filename_pc(filename_pc_stream.str());
   for (int j = 0; j != filename_pc.length(); ++j)
     if (filename_pc[j] == ' ') filename_pc[j] = '_';
 
   std::stringstream filename_krel_stream;
-  filename_krel_stream << plist.get<std::string>("WRM Type") << "_krel.txt";
+  filename_krel_stream << plist.get<std::string>("wrm type") << "_krel.txt";
   std::string filename_krel(filename_krel_stream.str());
   for (int j = 0; j != filename_krel.length(); ++j)
     if (filename_krel[j] == ' ') filename_krel[j] = '_';

--- a/src/pks/flow/constitutive_relations/wrm/rel_perm_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/wrm/rel_perm_evaluator.hh
@@ -83,7 +83,7 @@ Using the same set of van Genuchten model paramters for WRM and relative permeab
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />
@@ -131,7 +131,7 @@ parameters to Brooks-Corey parameters.
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />
@@ -142,7 +142,7 @@ parameters to Brooks-Corey parameters.
       <ParameterList name="relative permeability parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="Brooks-Corey" />
+          <Parameter name="wrm type" type="string" value="Brooks-Corey" />
           <Parameter name="Brooks Corey lambda [-]" type="double" value="0.49" />
           <Parameter name="Brooks Corey saturted matric suction [Pa]" type="double" value="32439.03" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />

--- a/src/pks/flow/constitutive_relations/wrm/rel_perm_frzBC_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/wrm/rel_perm_frzBC_evaluator.hh
@@ -55,7 +55,7 @@ method 2.
    * `"omega [-]`" ``[double]`` **2.0** A scale dependent parameter in the relative permeability model.
      See paper Niu & Yang (2006) for details about the model. Typical values range from 2-3.
 
-   * `"model parameters`" ``[string]``  **WRM parameters** ``[WRM-typedinline-spec-list]``
+   * `"model parameters`" ``[string]``  **WRM parameters** ``[wrm-typedinline-spec-list]``
      List (by region) of WRM specs. This will copy `"WRM parameters`" given in `"model parameters`"
      under state here to evaluate relative permeability. If use `"WRM parameters`", both WRM and
      relative permeability evaluators use the same set of `"WRM parameters`", which can be van Genuchten
@@ -100,7 +100,7 @@ parameters to Brooks-Corey parameters.
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />
@@ -111,7 +111,7 @@ parameters to Brooks-Corey parameters.
       <ParameterList name="relative permeability parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="Brooks-Corey" />
+          <Parameter name="wrm type" type="string" value="Brooks-Corey" />
           <Parameter name="Brooks Corey lambda [-]" type="double" value="0.49" />
           <Parameter name="Brooks Corey saturted matric suction [Pa]" type="double" value="32439.03" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />

--- a/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/wrm/rel_perm_sutraice_evaluator.hh
@@ -42,7 +42,7 @@ Some additional parameters are available.
      and K_sat is very small.  To avoid roundoff propagation issues, rescaling
      this quantity by offsetting and equal values is encourage.  Typically 10^7 or so is good.
 
-   * `"model parameters`" ``[string]``  **WRM parameters** ``[WRM-typedinline-spec-list]``
+   * `"model parameters`" ``[string]``  **WRM parameters** ``[wrm-typedinline-spec-list]``
      List (by region) of WRM specs. This will copy `"WRM parameters`" given in `"model parameters`"
      under state here to evaluate relative permeability. If use `"WRM parameters`", both WRM and
      relative permeability evaluators use the same set of `"WRM parameters`", which can be van Genuchten
@@ -82,7 +82,7 @@ Using the same set of van Genuchten model paramters for WRM and relative permeab
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />

--- a/src/pks/flow/constitutive_relations/wrm/wrm_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/wrm/wrm_evaluator.hh
@@ -58,7 +58,7 @@ Example:
       <ParameterList name="WRM parameters" type="ParameterList">
         <ParameterList name="domain" type="ParameterList">
           <Parameter name="region" type="string" value="domain" />
-          <Parameter name="WRM Type" type="string" value="van Genuchten" />
+          <Parameter name="wrm type" type="string" value="van Genuchten" />
           <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2e-05" />
           <Parameter name="van Genuchten n [-]" type="double" value="1.58" />
           <Parameter name="residual saturation [-]" type="double" value="0.2" />

--- a/src/pks/flow/constitutive_relations/wrm/wrm_factory.cc
+++ b/src/pks/flow/constitutive_relations/wrm/wrm_factory.cc
@@ -15,6 +15,8 @@
    ------------------------------------------------------------------------- */
 
 #include <string>
+
+#include "errors.hh"
 #include "wrm_factory.hh"
 
 namespace Amanzi {
@@ -26,14 +28,23 @@ WRMFactory::createWRM(Teuchos::ParameterList& plist)
 {
   std::string wrm_typename;
   // need to deprecate "WRM Type"
-  if (plist.isParameter("wrm type"))
+  if (plist.isParameter("wrm type")) {
     wrm_typename = plist.get<std::string>("wrm type");
-  else if (plist.isParameter("WRM Type"))
-    wrm_typename = plist.get<std::string>("WRM Type");
-  else if (plist.isParameter("WRM type"))
-    wrm_typename = plist.get<std::string>("WRM type");
-  else
+  } else if (plist.isParameter("WRM Type")) {
+    Errors::Message msg;
+    msg << "WRMFactory: deprecated parameter \"WRM Type\" in list \""
+        << plist.name() << "\" -- new parameter name is \"wrm type\"";
+    Exceptions::amanzi_throw(msg);
+  } else if (plist.isParameter("WRM type")) {
+    Errors::Message msg;
+    msg << "WRMFactory: deprecated parameter \"WRM type\" in list \""
+        << plist.name() << "\" -- new parameter name is \"wrm type\"";
+    Exceptions::amanzi_throw(msg);
+  } else {
+    // throw the missing parameter error
     wrm_typename = plist.get<std::string>("wrm type");
+  }
+
   return Teuchos::rcp(CreateInstance(wrm_typename, plist));
 };
 

--- a/src/pks/flow/constitutive_relations/wrm/wrm_permafrost_factory.cc
+++ b/src/pks/flow/constitutive_relations/wrm/wrm_permafrost_factory.cc
@@ -25,7 +25,7 @@ Teuchos::RCP<WRMPermafrostModel>
 WRMPermafrostFactory::createWRMPermafrostModel(Teuchos::ParameterList& plist,
                                                const Teuchos::RCP<WRM>& wrm)
 {
-  std::string model_typename = plist.get<std::string>("permafrost WRM type");
+  std::string model_typename = plist.get<std::string>("permafrost wrm type");
   Teuchos::RCP<WRMPermafrostModel> model = Teuchos::rcp(CreateInstance(model_typename, plist));
   model->set_WRM(wrm);
   return model;

--- a/src/pks/flow/constitutive_relations/wrm/wrm_plants_christoffersen.hh
+++ b/src/pks/flow/constitutive_relations/wrm/wrm_plants_christoffersen.hh
@@ -12,7 +12,7 @@
   <ul>Native Spec Example</>
     <ParameterList name="moss" type="ParameterList">
       <Parameter name="region" type="string" value="moss" />
-      <Parameter name="WRM Type" type="string" value="van Genuchten" />
+      <Parameter name="wrm type" type="string" value="van Genuchten" />
       <Parameter name="van Genuchten alpha" type="double" value="0.002" />
       <Parameter name="van Genuchten m" type="double" value="0.2" />
       <Parameter name="residual saturation" type="double" value="0.0" />

--- a/tools/input_converters/xml-1.3-1.4.py
+++ b/tools/input_converters/xml-1.3-1.4.py
@@ -139,7 +139,8 @@ def density_units(xml):
 
 def rh_to_vp(xml):
     """Converts relative humidity to vapor pressure."""
-    import warnings
+    import logging
+
     for ev in asearch.findall_path(xml, ["state", "evaluators", "surface-relative_humidity"], no_skip=True):
         ev.setName("surface-vapor_pressure_air")
         for fname, hname in zip(["function-tabular", "function-bilinear-and-time"], ["y header", "value header"]):
@@ -147,9 +148,20 @@ def rh_to_vp(xml):
                 y_header = asearch.find_path(ev, ["function", "domain", "function", fname, hname], no_skip=True)
                 y_header.setValue("vapor pressure air [Pa]")
             except aerrors.MissingXMLError:
-                warnings.warn("Unable to update relative_humidity --> vapor_pressure_air: this must be done manually.")
+                logging.warning("Manually update is required! Make sure to use the name of the air vapor pressure in your forcing dataset for the \"value header\" of \"surface-vapor_pressure_air\".")
             else:
-                warnings.warn("Changing relative_humidity --> vapor_pressure; please update your forcing data to include vapor pressure rather than relative humidity.  One way to do this is to run `$ATS_SRC_DIR/tools/utils/rh_to_vp.py --inplace path/to/daymet.h5`")
+                logging.warning("Changing relative_humidity --> vapor_pressure; please update your forcing data to include vapor pressure rather than relative humidity.  One way to do this is to run `$ATS_SRC_DIR/tools/utils/rh_to_vp.py --inplace path/to/daymet.h5`")
+    
+    for match in asearch.findall_path(xml, ["observations", "variable"]):
+        if "relative_humidity" in match.getValue():
+            match.setValue(match.getValue().replace("relative_humidity", "vapor_pressure_air"))
+            logging.warning("The surface-relative_humidity in observations has been changed to surface-vapor_pressure_air. You may want to change the corresponding output variable name, e.g., from \"relative humidity [-]\" to \"vapor pressure air [Pa]\".")
+
+    # delete relative humidity key if exists
+    try:
+        _ = asearch.remove_element(xml, "relative humidity key", allow_multiple=True)
+    except aerrors.MissingXMLError:
+        pass
 
 
 def pk_flow_reactive_transport(xml):

--- a/tools/input_converters/xml-1.4-master.py
+++ b/tools/input_converters/xml-1.4-master.py
@@ -431,16 +431,17 @@ def rename_wrm_rel_perm_evaluator(xml):
             eval_type.setValue("relative permeability, van Genuchten")
         
 
-def copy_gas_liquid(xml):
-    evals_list = asearch.find_path(xml, ["state", "evaluators"], no_skip=True)
-    try:
-        sat_gas_eval = next(eval_list for eval_list in evals_list if "saturation_gas" in eval_list.getName())
-    except StopIteration:
-        return
-    else:
-        sat_liq_eval = copy.deepcopy(sat_gas_eval)
-        sat_liq_eval.setName(sat_gas_eval.getName().replace("saturation_gas", "saturation_liquid"))
-        evals_list.append(sat_liq_eval)
+def lowercase_wrmtype(xml):
+    def _wrmtype(match, wrmtype_uppercase):
+        name = match.getName()
+        if wrmtype_uppercase in name:
+            name = name.replace(wrmtype_uppercase, 'wrm type')
+            match.setName(name)
+            
+    matches = xml.findall('.//')
+    for match in matches:
+        for i in ['WRM Type', 'WRM type']:
+            _wrmtype(match, i)
 
             
 def update(xml, transpiration_distribution=False, frozen_krel=False,
@@ -469,7 +470,7 @@ def update(xml, transpiration_distribution=False, frozen_krel=False,
 
     move_wrm_to_state_evaluators(xml)
     rename_wrm_rel_perm_evaluator(xml)
-    copy_gas_liquid(xml)
+    lowercase_wrmtype(xml)
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
#241 
- Removed the duplication of saturation_liquid 
- Changed all names include "WRM Type" or "WRM type" to "wrm type"
- Removed "relative humidity key" and changed "surface-relative_humidity" to "surface-vapor_pressure_air" for observations.
- "mass_flux" to "water_flux" in observations has been already included in xml-1.2-1.3.py.