### PR TITLE
Fix the issue for converting wrm type to lowercase

### DIFF
--- a/tools/input_converters/xml-1.4-master.py
+++ b/tools/input_converters/xml-1.4-master.py
@@ -430,10 +430,10 @@ def add_frz_relp_to_model_parameters(xml):
 
 
 def lowercase_wrmtype(xml):
-    rename_element(xml, "WRM type", "wrm type")
-    rename_element(xml, "WRM Type", "wrm type")
-    rename_element(xml, "permafrost WRM type", "permafrost wrm type")
-    rename_element(xml, "permafrost WRM Type", "permafrost wrm type")
+    replace_string_in_name(xml, "WRM type", "wrm type")
+    replace_string_in_name(xml, "WRM Type", "wrm type")
+    replace_string_in_name(xml, "permafrost WRM type", "permafrost wrm type")
+    replace_string_in_name(xml, "permafrost WRM Type", "permafrost wrm type")
 
     
 def brooks_corey(xml):


### PR DESCRIPTION
"rename_element" only allows for searching the old names at 1 depth. This cannot find capital "wrm type".