### PR TITLE
Rework of PKs to split out parseParameterList, make RequireEvaluator() call EnsureEvaluators()

### DIFF
--- a/src/executables/coordinator.cc
+++ b/src/executables/coordinator.cc
@@ -287,7 +287,6 @@ Coordinator::setup()
   // order matters here -- PKs set the leaves, then observations can use those
   // if provided, and setup finally deals with all secondaries and allocates memory
   pk_->set_tags(Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT);
-  pk_->modifyParameterList();
   pk_->parseParameterList();
   pk_->Setup();
   for (auto& obs : observations_) obs->Setup(S_.ptr());

--- a/src/executables/coordinator.cc
+++ b/src/executables/coordinator.cc
@@ -284,8 +284,9 @@ Coordinator::setup()
   S_->require_time(Amanzi::Tags::CURRENT);
   S_->require_time(Amanzi::Tags::NEXT);
 
-  // order matters here -- PKs set the leaves, then observations can use those
-  // if provided, and setup finally deals with all secondaries and allocates memory
+  // order matters here -- PK::Setup() set the leaves, then observations can
+  // use those if provided, and State::Setup finally deals with all secondaries
+  // and allocates memory
   pk_->set_tags(Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT);
   pk_->parseParameterList();
   pk_->Setup();

--- a/src/executables/coordinator.cc
+++ b/src/executables/coordinator.cc
@@ -287,6 +287,8 @@ Coordinator::setup()
   // order matters here -- PKs set the leaves, then observations can use those
   // if provided, and setup finally deals with all secondaries and allocates memory
   pk_->set_tags(Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT);
+  pk_->modifyParameterList();
+  pk_->parseParameterList();
   pk_->Setup();
   for (auto& obs : observations_) obs->Setup(S_.ptr());
   S_->Setup();

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -212,22 +212,17 @@ ELM_ATSDriver::setup()
   requireAtNext(wc_key_, Amanzi::Tags::NEXT, *S_)
     .SetMesh(mesh_subsurf_)->AddComponent("cell", AmanziMesh::CELL, 1);
 
-
-
   requireAtNext(evap_key_, Amanzi::Tags::NEXT, *S_)
    .SetMesh(mesh_surf_)->AddComponent("cell", AmanziMesh::CELL, 1);
   requireAtNext(trans_key_, Amanzi::Tags::NEXT, *S_)
    .SetMesh(mesh_subsurf_)->AddComponent("cell", AmanziMesh::CELL, 1);
 
-
-  Coordinator::setup();
-  // NOTE: These must be called after Coordinator::setup() until PK_Phys_Default modifies the state eval
-  // list in constructor -- otherwise this primary variable is not available
-  // yet. See amanzi/ats#167 --ETC
   requireAtNext(infilt_key_, Amanzi::Tags::NEXT, *S_)
     .SetMesh(mesh_surf_)->AddComponent("cell", AmanziMesh::CELL, 1);
   requireAtNext(pres_key_, Amanzi::Tags::NEXT, *S_, "flow")
     .SetMesh(mesh_subsurf_)->AddComponent("cell", AmanziMesh::CELL, 1);
+
+  Coordinator::setup();
 }
 
 

--- a/src/executables/test/executable_coupled_water.cc
+++ b/src/executables/test/executable_coupled_water.cc
@@ -77,6 +77,7 @@ struct CoupledWaterProblem {
     Amanzi::PKFactory pk_factory;
     auto pk_as_pk = pk_factory.CreatePK("coupled water", pk_tree_list, plist, S, soln);
     pk = Teuchos::rcp_dynamic_cast<MPCCoupledWater>(pk_as_pk);
+    pk->parseParameterList();
     AMANZI_ASSERT(pk.get());
 
     // setup stage

--- a/src/pks/deform/volumetric_deformation.cc
+++ b/src/pks/deform/volumetric_deformation.cc
@@ -30,7 +30,14 @@ VolumetricDeformation::VolumetricDeformation(Teuchos::ParameterList& pk_tree,
     PK_Physical_Default(pk_tree, glist, S, solution),
     surf_mesh_(Teuchos::null),
     deformed_this_step_(false)
+{}
+
+
+void
+VolumetricDeformation::parseParameterList()
 {
+  PK_Physical_Default::parseParameterList();
+
   dt_max_ = plist_->get<double>("max time step [s]", std::numeric_limits<double>::max());
 
   // The deformation mode describes how to calculate new cell volume from a

--- a/src/pks/deform/volumetric_deformation.hh
+++ b/src/pks/deform/volumetric_deformation.hh
@@ -129,7 +129,8 @@ class VolumetricDeformation : public PK_Physical_Default {
                         const Teuchos::RCP<State>& S,
                         const Teuchos::RCP<TreeVector>& solution);
 
-  // ConstantTemperature is a PK
+  void parseParameterList() override;
+
   // -- Setup data
   virtual void Setup() override;
 

--- a/src/pks/energy/energy_base.hh
+++ b/src/pks/energy/energy_base.hh
@@ -74,13 +74,11 @@ Solves an advection-diffusion equation for energy:
     * `"source key`" ``[string]`` **DOMAIN-total_energy_source** Typically
       not set, as the default is good. ``[MJ s^-1]``
 
-    * `"source term is differentiable`" ``[bool]`` **true** Can the source term
-      be differentiated with respect to the primary variable?
-
-    * `"source term finite difference`" ``[bool]`` **false** If the source term
-      is not diffferentiable, we can do a finite difference approximation of
-      this derivative anyway.  This is useful for difficult-to-differentiate
-      terms like a surface energy balance, which includes many terms.
+    * `"source term finite difference`" ``[bool]`` **false** Option to do a
+      finite difference approximation of the source term's derivative with
+      respect to the primary variable.  This is useful for
+      difficult-to-differentiate terms like a surface energy balance, which
+      includes many terms.
 
     END
 

--- a/src/pks/energy/energy_base.hh
+++ b/src/pks/energy/energy_base.hh
@@ -183,9 +183,6 @@ class EnergyBase : public PK_PhysicalBDF_Default {
   virtual ~EnergyBase() {}
 
   // call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() override;
-
-  // read said list
   virtual void parseParameterList() override;
 
   // EnergyBase is a PK

--- a/src/pks/energy/energy_base.hh
+++ b/src/pks/energy/energy_base.hh
@@ -182,6 +182,12 @@ class EnergyBase : public PK_PhysicalBDF_Default {
   // Virtual destructor
   virtual ~EnergyBase() {}
 
+  // call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() override;
+
+  // read said list
+  virtual void parseParameterList() override;
+
   // EnergyBase is a PK
   // -- Setup data
   virtual void Setup() override;

--- a/src/pks/energy/energy_base_pk.cc
+++ b/src/pks/energy/energy_base_pk.cc
@@ -66,6 +66,14 @@ EnergyBase::modifyParameterList()
   if (!plist_->isParameter("conserved quantity key suffix"))
     plist_->set<std::string>("conserved quantity key suffix", "energy");
 
+  // need to deprecate the use of enthalpy list in the PK! --ETC
+  enthalpy_key_ = Keys::readKey(*plist_, domain_, "enthalpy", "enthalpy");
+  if (plist_->isSublist("enthalpy evaluator")) {
+    Teuchos::ParameterList& enth_list = S_->GetEvaluatorList(enthalpy_key_);
+    enth_list.setParameters(plist_->sublist("enthalpy evaluator"));
+    enth_list.set<std::string>("evaluator type", "enthalpy");
+  }
+
   PK_PhysicalBDF_Default::modifyParameterList();
 }
 
@@ -97,7 +105,6 @@ EnergyBase::parseParameterList()
 
   // get keys
   wc_key_ = Keys::readKey(*plist_, domain_, "water content", "water_content");
-  enthalpy_key_ = Keys::readKey(*plist_, domain_, "enthalpy", "enthalpy");
   flux_key_ = Keys::readKey(*plist_, domain_, "water flux", "water_flux");
   energy_flux_key_ =
     Keys::readKey(*plist_, domain_, "diffusive energy flux", "diffusive_energy_flux");
@@ -307,11 +314,6 @@ EnergyBase::SetupEnergy_()
   // -- set up the evaluator for enthalpy, whether or not we advect the thing,
   //    we may need it for exchange fluxes with surface/subsurface coupling,
   //    etc.
-  if (plist_->isSublist("enthalpy evaluator")) {
-    Teuchos::ParameterList& enth_list = S_->GetEvaluatorList(enthalpy_key_);
-    enth_list.setParameters(plist_->sublist("enthalpy evaluator"));
-    enth_list.set<std::string>("evaluator type", "enthalpy");
-  }
   is_advection_term_ = plist_->get<bool>("include thermal advection", true);
   if (is_advection_term_) {
     // -- create the forward operator for the advection term

--- a/src/pks/energy/energy_base_pk.cc
+++ b/src/pks/energy/energy_base_pk.cc
@@ -55,7 +55,7 @@ EnergyBase::EnergyBase(Teuchos::ParameterList& FElist,
 
 // call to allow a PK to modify its own list or lists of its children.
 void
-EnergyBase::modifyParameterList()
+EnergyBase::parseParameterList()
 {
   if (!plist_->isParameter("absolute error tolerance")) {
     plist_->set("absolute error tolerance", 76.e-6);
@@ -74,14 +74,6 @@ EnergyBase::modifyParameterList()
     enth_list.set<std::string>("evaluator type", "enthalpy");
   }
 
-  PK_PhysicalBDF_Default::modifyParameterList();
-}
-
-
-// read said list
-void
-EnergyBase::parseParameterList()
-{
   PK_PhysicalBDF_Default::parseParameterList();
 
   // set a default error tolerance

--- a/src/pks/flow/constitutive_relations/sources/distributed_tiles_evaluator.hh
+++ b/src/pks/flow/constitutive_relations/sources/distributed_tiles_evaluator.hh
@@ -56,6 +56,11 @@ class DistributedTilesRateEvaluator : public EvaluatorSecondary {
 
   virtual void EnsureCompatibility(State& S) override;
 
+  // derivatives aren't implemented here
+  bool IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override {
+    return false;
+  }
+
  protected:
   // Required methods from EvaluatorSecondary
   virtual void Update_(State& S) override;

--- a/src/pks/flow/overland_pressure.hh
+++ b/src/pks/flow/overland_pressure.hh
@@ -41,8 +41,6 @@ Solves the diffusion wave equation for overland flow with pressure as a primary 
     * `"source key`" ``[string]`` **DOMAIN-water_source** Typically
       not set, as the default is good. ``[m s^-1]`` or ``[mol s^-1]``
     * `"water source in meters`" ``[bool]`` **true** Is the source term in ``[m s^-1]``?
-    * `"source term is differentiable`" ``[bool]`` **true** Can the source term
-      be differentiated with respect to the primary variable?
 
     END
 
@@ -268,7 +266,7 @@ class OverlandPressureFlow : public PK_PhysicalBDF_Default {
   Operators::UpwindMethod upwind_method_;
 
   bool is_source_term_;
-  bool source_term_is_differentiable_;
+  bool is_source_term_differentiable_;
   bool source_only_if_unfrozen_;
 
   bool modify_predictor_with_consistent_faces_;

--- a/src/pks/flow/overland_pressure.hh
+++ b/src/pks/flow/overland_pressure.hh
@@ -157,10 +157,7 @@ class OverlandPressureFlow : public PK_PhysicalBDF_Default {
   // Virtual destructor
   virtual ~OverlandPressureFlow() {}
 
-  // call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() override;
-
-  // read said list
+  // parse input list
   virtual void parseParameterList() override;
 
   // main methods

--- a/src/pks/flow/overland_pressure.hh
+++ b/src/pks/flow/overland_pressure.hh
@@ -157,6 +157,12 @@ class OverlandPressureFlow : public PK_PhysicalBDF_Default {
   // Virtual destructor
   virtual ~OverlandPressureFlow() {}
 
+  // call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() override;
+
+  // read said list
+  virtual void parseParameterList() override;
+
   // main methods
   // -- Initialize owned (dependent) variables.
   virtual void Setup() override;

--- a/src/pks/flow/overland_pressure_physics.cc
+++ b/src/pks/flow/overland_pressure_physics.cc
@@ -124,8 +124,7 @@ void
 OverlandPressureFlow::AddSourcesToPrecon_(double h)
 {
   // -- update the source term derivatives
-  if (is_source_term_ && source_term_is_differentiable_ &&
-      S_->GetEvaluator(source_key_, tag_next_).IsDifferentiableWRT(*S_, key_, tag_next_)) {
+  if (is_source_term_differentiable_) {
     S_->GetEvaluator(source_key_, tag_next_).UpdateDerivative(*S_, name_, key_, tag_next_);
     preconditioner_acc_->AddAccumulationTerm(
       S_->GetDerivative<CompositeVector>(source_key_, tag_next_, key_, tag_next_),

--- a/src/pks/flow/overland_pressure_pk.cc
+++ b/src/pks/flow/overland_pressure_pk.cc
@@ -41,6 +41,7 @@ OverlandPressureFlow::OverlandPressureFlow(Teuchos::ParameterList& pk_tree,
     PK_PhysicalBDF_Default(pk_tree, plist, S, solution),
     standalone_mode_(false),
     is_source_term_(false),
+    is_source_term_differentiable_(false),
     coupled_to_subsurface_via_head_(false),
     coupled_to_subsurface_via_flux_(false),
     perm_update_required_(true),
@@ -379,9 +380,8 @@ OverlandPressureFlow::SetupPhysicalEvaluators_()
       .SetMesh(mesh_)
       ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
 
-
-    source_term_is_differentiable_ = plist_->get<bool>("source term is differentiable", true);
-    if (source_term_is_differentiable_) {
+    if (S_->GetEvaluator(source_key_, tag_next_).IsDifferentiableWRT(*S_, key_, tag_next_)) {
+      is_source_term_differentiable_ = true;
       // require derivative of source
       S_->RequireDerivative<CompositeVector, CompositeVectorSpace>(
         source_key_, tag_next_, key_, tag_next_);

--- a/src/pks/flow/overland_pressure_pk.cc
+++ b/src/pks/flow/overland_pressure_pk.cc
@@ -56,7 +56,7 @@ OverlandPressureFlow::OverlandPressureFlow(Teuchos::ParameterList& pk_tree,
 
 
 void
-OverlandPressureFlow::modifyParameterList()
+OverlandPressureFlow::parseParameterList()
 {
   // set a default absolute tolerance
   if (!plist_->isParameter("absolute error tolerance"))
@@ -66,13 +66,6 @@ OverlandPressureFlow::modifyParameterList()
   if (!plist_->isParameter("conserved quantity key suffix"))
     plist_->set<std::string>("conserved quantity key suffix", "water_content");
 
-  PK_PhysicalBDF_Default::modifyParameterList();
-}
-
-
-void
-OverlandPressureFlow::parseParameterList()
-{
   PK_PhysicalBDF_Default::parseParameterList();
 
   // get keys

--- a/src/pks/flow/permafrost_pk.cc
+++ b/src/pks/flow/permafrost_pk.cc
@@ -74,9 +74,7 @@ Permafrost::SetupPhysicalEvaluators_()
 
   //    and at the current time, where it is a copy evaluator
   requireAtCurrent(sat_key_, tag_current_, *S_, name_, true);
-  // S_->RequireEvaluator(sat_key_, tag_current_);
   requireAtCurrent(sat_ice_key_, tag_current_, *S_, name_, true);
-  // S_->RequireEvaluator(sat_ice_key_, tag_current_);
 
   // -- the rel perm evaluator, also with the same underlying WRM.
   S_->GetEvaluatorList(coef_key_).set<double>("permeability rescaling", perm_scale_);

--- a/src/pks/flow/richards.hh
+++ b/src/pks/flow/richards.hh
@@ -255,9 +255,6 @@ class Richards : public PK_PhysicalBDF_Default {
   virtual ~Richards() {}
 
   // call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() override;
-
-  // read said list
   virtual void parseParameterList() override;
 
   // -- Set requirements of data and evaluators

--- a/src/pks/flow/richards.hh
+++ b/src/pks/flow/richards.hh
@@ -254,6 +254,12 @@ class Richards : public PK_PhysicalBDF_Default {
 
   virtual ~Richards() {}
 
+  // call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() override;
+
+  // read said list
+  virtual void parseParameterList() override;
+
   // -- Set requirements of data and evaluators
   virtual void Setup() override;
 

--- a/src/pks/flow/richards.hh
+++ b/src/pks/flow/richards.hh
@@ -51,9 +51,6 @@ Solves Richards equation:
 
    * `"source key`" ``[string]`` **DOMAIN-water_source** Typically not
      set, as the default is good. ``[mol s^-1]``
-   * `"source term is differentiable`" ``[bool]`` **true** Can the
-     source term be differentiated with respect to the primary
-     variable?
    * `"explicit source term`" ``[bool]`` **false** Apply the source
      term from the previous time step.
 
@@ -360,7 +357,7 @@ class Richards : public PK_PhysicalBDF_Default {
   bool modify_predictor_wc_;
   bool symmetric_;
   bool is_source_term_;
-  bool source_term_is_differentiable_;
+  bool is_source_term_differentiable_;
   bool explicit_source_;
   std::string clobber_policy_;
   bool clobber_boundary_flux_dir_;

--- a/src/pks/flow/richards_physics.cc
+++ b/src/pks/flow/richards_physics.cc
@@ -116,8 +116,7 @@ void
 Richards::AddSourcesToPrecon_(double h)
 {
   // nonlinear water sources include a dQ/dp term into PC
-  if (is_source_term_ && !explicit_source_ && source_term_is_differentiable_ &&
-      S_->GetEvaluator(source_key_, tag_next_).IsDifferentiableWRT(*S_, key_, tag_next_)) {
+  if (is_source_term_differentiable_) {
     S_->GetEvaluator(source_key_, tag_next_).UpdateDerivative(*S_, name_, key_, tag_next_);
     preconditioner_acc_->AddAccumulationTerm(
       S_->GetDerivative<CompositeVector>(source_key_, tag_next_, key_, tag_next_),

--- a/src/pks/flow/richards_pk.cc
+++ b/src/pks/flow/richards_pk.cc
@@ -65,7 +65,7 @@ Richards::Richards(Teuchos::ParameterList& pk_tree,
 
 
 void
-Richards::modifyParameterList()
+Richards::parseParameterList()
 {
   // set some defaults for inherited PKs
   if (!plist_->isParameter("conserved quantity key suffix"))
@@ -75,16 +75,6 @@ Richards::modifyParameterList()
   if (!plist_->isParameter("absolute error tolerance"))
     plist_->set("absolute error tolerance", .5 * .1 * 55000.); // phi * s * nl
 
-  PK_PhysicalBDF_Default::modifyParameterList();
-}
-
-
-void
-Richards::parseParameterList()
-{
-  // parse inherited lists
-  PK_PhysicalBDF_Default::parseParameterList();
-
   // get field names
   mass_dens_key_ = Keys::readKey(*plist_, domain_, "mass density", "mass_density_liquid");
   molar_dens_key_ = Keys::readKey(*plist_, domain_, "molar density", "molar_density_liquid");
@@ -92,7 +82,10 @@ Richards::parseParameterList()
   coef_key_ = Keys::readKey(*plist_, domain_, "conductivity", "relative_permeability");
   uw_coef_key_ =
     Keys::readKey(*plist_, domain_, "upwinded conductivity", "upwind_relative_permeability");
+
   flux_key_ = Keys::readKey(*plist_, domain_, "darcy flux", "water_flux");
+  requireAtNext(flux_key_, tag_next_, *S_, name_);
+
   flux_dir_key_ = Keys::readKey(*plist_, domain_, "darcy flux direction", "water_flux_direction");
   velocity_key_ = Keys::readKey(*plist_, domain_, "darcy velocity", "darcy_velocity");
   sat_key_ = Keys::readKey(*plist_, domain_, "saturation", "saturation_liquid");
@@ -135,6 +128,9 @@ Richards::parseParameterList()
     Key domain_surf = Keys::readDomainHint(*plist_, domain_, "subsurface", "surface");
     ss_primary_key_ = Keys::readKey(*plist_, domain_surf, "pressure", "pressure");
   }
+
+  // parse inherited lists
+  PK_PhysicalBDF_Default::parseParameterList();
 }
 
 

--- a/src/pks/mpc/mpc.hh
+++ b/src/pks/mpc/mpc.hh
@@ -65,7 +65,6 @@ class MPC : virtual public PK {
 
   // PK methods
   // -- parsing plist
-  virtual void modifyParameterList() override;
   virtual void parseParameterList() override;
 
   // -- setup
@@ -120,14 +119,6 @@ class MPC : virtual public PK {
   SubPKList sub_pks_;
 };
 
-
-
-template <class PK_t>
-void
-MPC<PK_t>::modifyParameterList()
-{
-  for (auto& pk : sub_pks_) pk->modifyParameterList();
-}
 
 template <class PK_t>
 void

--- a/src/pks/mpc/mpc.hh
+++ b/src/pks/mpc/mpc.hh
@@ -64,6 +64,10 @@ class MPC : virtual public PK {
   {}
 
   // PK methods
+  // -- parsing plist
+  virtual void modifyParameterList() override;
+  virtual void parseParameterList() override;
+
   // -- setup
   virtual void Setup() override;
 
@@ -115,6 +119,22 @@ class MPC : virtual public PK {
 
   SubPKList sub_pks_;
 };
+
+
+
+template <class PK_t>
+void
+MPC<PK_t>::modifyParameterList()
+{
+  for (auto& pk : sub_pks_) pk->modifyParameterList();
+}
+
+template <class PK_t>
+void
+MPC<PK_t>::parseParameterList()
+{
+  for (auto& pk : sub_pks_) pk->parseParameterList();
+}
 
 
 // -----------------------------------------------------------------------------

--- a/src/pks/mpc/mpc_coupled_cells.cc
+++ b/src/pks/mpc/mpc_coupled_cells.cc
@@ -93,10 +93,9 @@ MPCCoupledCells::Setup()
   S_->RequireEvaluator(A_key_, tag_next_);
   S_->RequireEvaluator(y2_key_, tag_next_);
 
-  // BROKEN CONCEPT: See Amanzi ticket #654
-  // if (S_->GetEvaluator(A_key_, tag_next_).IsDifferentiableWRT(*S_, y2_key_, tag_next_))
-  S_->RequireDerivative<CompositeVector, CompositeVectorSpace>(
-    A_key_, tag_next_, y2_key_, tag_next_);
+  if (S_->GetEvaluator(A_key_, tag_next_).IsDifferentiableWRT(*S_, y2_key_, tag_next_))
+    S_->RequireDerivative<CompositeVector, CompositeVectorSpace>(
+      A_key_, tag_next_, y2_key_, tag_next_);
 
   if (!plist_->get<bool>("no dA/dy2 block", false)) {
     Teuchos::ParameterList& acc_pc_plist = plist_->sublist("dA_dy2 accumulation preconditioner");
@@ -114,10 +113,9 @@ MPCCoupledCells::Setup()
   S_->RequireEvaluator(B_key_, tag_next_);
   S_->RequireEvaluator(y1_key_, tag_next_);
 
-  // BROKEN CONCEPT: See Amanzi ticket #654
-  // if (S_->GetEvaluator(B_key_, tag_next_).IsDifferentiableWRT(*S_, y1_key_, tag_next_))
-  S_->RequireDerivative<CompositeVector, CompositeVectorSpace>(
-    B_key_, tag_next_, y1_key_, tag_next_);
+  if (S_->GetEvaluator(B_key_, tag_next_).IsDifferentiableWRT(*S_, y1_key_, tag_next_))
+    S_->RequireDerivative<CompositeVector, CompositeVectorSpace>(
+      B_key_, tag_next_, y1_key_, tag_next_);
 
   if (!plist_->get<bool>("no dB/dy1 block", false)) {
     Teuchos::ParameterList& acc_pc_plist = plist_->sublist("dB_dy1 accumulation preconditioner");

--- a/src/pks/mpc/mpc_coupled_cells.cc
+++ b/src/pks/mpc/mpc_coupled_cells.cc
@@ -49,17 +49,23 @@
 namespace Amanzi {
 
 void
+MPCCoupledCells::parseParameterList()
+{
+  StrongMPC<PK_PhysicalBDF_Default>::parseParameterList();
+
+  Key domain = plist_->get<std::string>("domain name");
+  mesh_ = S_->GetMesh(domain);
+
+  A_key_ = Keys::readKey(*plist_, domain, "conserved quantity A");
+  B_key_ = Keys::readKey(*plist_, domain, "conserved quantity B");
+  y1_key_ = Keys::readKey(*plist_, domain, "primary variable A");
+  y2_key_ = Keys::readKey(*plist_, domain, "primary variable B");
+}
+
+void
 MPCCoupledCells::Setup()
 {
   StrongMPC<PK_PhysicalBDF_Default>::Setup();
-
-  A_key_ = plist_->get<std::string>("conserved quantity A");
-  B_key_ = plist_->get<std::string>("conserved quantity B");
-  y1_key_ = plist_->get<std::string>("primary variable A");
-  y2_key_ = plist_->get<std::string>("primary variable B");
-
-  Key mesh_key = plist_->get<std::string>("domain name");
-  mesh_ = S_->GetMesh(mesh_key);
 
   // set up debugger
   db_ = sub_pks_[0]->debugger();

--- a/src/pks/mpc/mpc_coupled_cells.hh
+++ b/src/pks/mpc/mpc_coupled_cells.hh
@@ -76,6 +76,7 @@ class MPCCoupledCells : public StrongMPC<PK_PhysicalBDF_Default> {
     : PK(FElist, plist, S, solution), StrongMPC<PK_PhysicalBDF_Default>(FElist, plist, S, solution)
   {}
 
+  void parseParameterList() override;
   virtual void Setup() override;
 
   // applies preconditioner to u and returns the result in Pu

--- a/src/pks/mpc/mpc_coupled_dualmedia_water.cc
+++ b/src/pks/mpc/mpc_coupled_dualmedia_water.cc
@@ -24,16 +24,10 @@ MPCCoupledDualMediaWater::MPCCoupledDualMediaWater(
 
 
 void
-MPCCoupledDualMediaWater::modifyParameterList()
-{
-  StrongMPC<PK_BDF_Default>::modifyParameterList();
-
-  pks_list_->sublist(names[1]).set("coupled to subsurface via head", true);
-}
-
-void
 MPCCoupledDualMediaWater::parseParameterList()
 {
+  pks_list_->sublist(names[1]).set("coupled to subsurface via head", true);
+
   StrongMPC<PK_BDF_Default>::parseParameterList();
 
   domain_ = plist_->get<std::string>("domain name", "domain");
@@ -41,6 +35,7 @@ MPCCoupledDualMediaWater::parseParameterList()
   macro_flux_key_ = Keys::readKey(*plist_, domain_macropore_, "macropore water flux", "water_flux");
   macro_flux_key_ = Keys::readKey(*plist_, domain_, "matrix water flux", "water_flux");
 }
+
 
 void
 MPCCoupledDualMediaWater::Setup(const Teuchos::Ptr<State>& S)

--- a/src/pks/mpc/mpc_coupled_dualmedia_water.cc
+++ b/src/pks/mpc/mpc_coupled_dualmedia_water.cc
@@ -24,20 +24,30 @@ MPCCoupledDualMediaWater::MPCCoupledDualMediaWater(
 
 
 void
+MPCCoupledDualMediaWater::modifyParameterList()
+{
+  StrongMPC<PK_BDF_Default>::modifyParameterList();
+
+  pks_list_->sublist(names[1]).set("coupled to subsurface via head", true);
+}
+
+void
+MPCCoupledDualMediaWater::parseParameterList()
+{
+  StrongMPC<PK_BDF_Default>::parseParameterList();
+
+  domain_ = plist_->get<std::string>("domain name", "domain");
+  domain_macropore_ = Keys::readDomainHint(*plist_, domain_, "domain", "macropore");
+  macro_flux_key_ = Keys::readKey(*plist_, domain_macropore_, "macropore water flux", "water_flux");
+  macro_flux_key_ = Keys::readKey(*plist_, domain_, "matrix water flux", "water_flux");
+}
+
+void
 MPCCoupledDualMediaWater::Setup(const Teuchos::Ptr<State>& S)
 {
   // tweak the sub-PK parameter lists
   StrongMPC<PK_BDF_Default>::Setup(S);
 
-  std::cout << "Setup\n";
-  Teuchos::Array<std::string> names = plist_->get<Teuchos::Array<std::string>>("PKs order");
-  int npks = names.size();
-  for (int i = 0; i != npks; ++i) {
-    Teuchos::RCP<const CompositeVectorSpace> tmp = solution_->Map().SubVector(i)->Data();
-    std::cout << names[i] << " " << tmp << "\n";
-  }
-
-  pks_list_->sublist(names[1]).set("coupled to subsurface via head", true);
   // cast the PKs
   integrated_flow_pk_ = Teuchos::rcp_dynamic_cast<StrongMPC<PK_PhysicalBDF_Default>>(sub_pks_[0]);
   AMANZI_ASSERT(integrated_flow_pk_ != Teuchos::null);
@@ -45,9 +55,6 @@ MPCCoupledDualMediaWater::Setup(const Teuchos::Ptr<State>& S)
   macro_flow_pk_ = sub_pks_[1];
   matrix_flow_pk_ = integrated_flow_pk_->get_subpk(0);
   surf_flow_pk_ = integrated_flow_pk_->get_subpk(1);
-
-  macro_flux_key_ = "macropore-mass_flux";
-  matrix_flux_key_ = "water_flux";
 }
 
 void
@@ -78,8 +85,8 @@ MPCCoupledDualMediaWater::Initialize(const Teuchos::Ptr<State>& S)
 
   // off-diagonal blocks are coupled PDEs
   // -- minimum composite vector spaces containing the coupling term
-  auto mesh_matrix = S_->GetMesh("domain");
-  auto mesh_macropore = S_->GetMesh("macropore");
+  auto mesh_matrix = S_->GetMesh(domain_);
+  auto mesh_macropore = S_->GetMesh(domain_macropore_);
 
   auto& mmap0 = solution_->SubVector(0)->SubVector(0)->Data()->ViewComponent("face", false)->Map();
   auto& gmap0 = solution_->SubVector(0)->SubVector(0)->Data()->ViewComponent("face", true)->Map();

--- a/src/pks/mpc/mpc_coupled_dualmedia_water.hh
+++ b/src/pks/mpc/mpc_coupled_dualmedia_water.hh
@@ -32,7 +32,6 @@ class MPCCoupledDualMediaWater : public StrongMPC<PK_BDF_Default> {
                            const Teuchos::RCP<State>& S,
                            const Teuchos::RCP<TreeVector>& soln);
 
-  void modifyParameterList() override;
   void parseParameterList() override;
 
   virtual void Setup(const Teuchos::Ptr<State>& S);

--- a/src/pks/mpc/mpc_coupled_dualmedia_water.hh
+++ b/src/pks/mpc/mpc_coupled_dualmedia_water.hh
@@ -32,6 +32,9 @@ class MPCCoupledDualMediaWater : public StrongMPC<PK_BDF_Default> {
                            const Teuchos::RCP<State>& S,
                            const Teuchos::RCP<TreeVector>& soln);
 
+  void modifyParameterList() override;
+  void parseParameterList() override;
+
   virtual void Setup(const Teuchos::Ptr<State>& S);
   virtual void Initialize(const Teuchos::Ptr<State>& S);
 
@@ -69,6 +72,8 @@ class MPCCoupledDualMediaWater : public StrongMPC<PK_BDF_Default> {
   Teuchos::RCP<PK_BDF_Default> matrix_flow_pk_;
 
 
+  Key domain_;
+  Key domain_macropore_;
   Key total_ss_flux_key_, matrix_flux_key_, macro_flux_key_;
 
   // debugger for dumping vectors

--- a/src/pks/mpc/mpc_coupled_reactivetransport.cc
+++ b/src/pks/mpc/mpc_coupled_reactivetransport.cc
@@ -32,6 +32,12 @@ MPCCoupledReactiveTransport::MPCCoupledReactiveTransport(
 
   alquimia_timer_ = Teuchos::TimeMonitor::getNewCounter("alquimia " + name());
   alquimia_surf_timer_ = Teuchos::TimeMonitor::getNewCounter("alquimia surface " + name());
+}
+
+void
+MPCCoupledReactiveTransport::parseParameterList()
+{
+  WeakMPC::parseParameterList();
 
   domain_ = Keys::readDomain(*plist_, "domain", "domain");
   domain_surf_ = Keys::readDomainHint(*plist_, domain_, "domain", "surface");

--- a/src/pks/mpc/mpc_coupled_reactivetransport.hh
+++ b/src/pks/mpc/mpc_coupled_reactivetransport.hh
@@ -34,6 +34,9 @@ class MPCCoupledReactiveTransport : public WeakMPC {
                               const Teuchos::RCP<State>& S,
                               const Teuchos::RCP<TreeVector>& soln);
 
+
+  void parseParameterList() override;
+
   // PK methods
   virtual double get_dt() override;
   virtual void Setup() override;

--- a/src/pks/mpc/mpc_coupled_transport.cc
+++ b/src/pks/mpc/mpc_coupled_transport.cc
@@ -72,7 +72,8 @@ MPCCoupledTransport::parseParameterList()
     src_coupling.set<Teuchos::Array<std::string>>("regions", regs);
     Teuchos::ParameterList& tmp = src_coupling.sublist("fields");
     tmp.set<std::string>("flux key", ss_flux_key);
-    // NOTE: FIXME --ETC amanzi/amanzi#646
+    // NOTE: FIXME --ETC amanzi/amanzi#646 Currently flux field is hard-coded
+    // as NEXT both here and as transport PK's flow_tag
     tmp.set<std::string>("flux copy key", Tags::NEXT.get());
     tmp.set<std::string>("conserved quantity key", surf_tcc_key);
     tmp.set<std::string>("conserved quantity copy key", tag_next_.get());

--- a/src/pks/mpc/mpc_coupled_transport.cc
+++ b/src/pks/mpc/mpc_coupled_transport.cc
@@ -25,7 +25,7 @@ MPCCoupledTransport::MPCCoupledTransport(Teuchos::ParameterList& pk_tree,
 
 
 void
-MPCCoupledTransport::modifyParameterList()
+MPCCoupledTransport::parseParameterList()
 {
   name_ss_ = sub_pks_[0]->name();
   name_surf_ = sub_pks_[1]->name();
@@ -33,21 +33,20 @@ MPCCoupledTransport::modifyParameterList()
   Key domain_ss = pks_list_->sublist(name_ss_).get<std::string>("domain name", "domain");
   Key domain_surf = pks_list_->sublist(name_surf_).get<std::string>("domain name", "surface");
 
-  auto& bc_list =
-    pks_list_->sublist(name_ss_).sublist("boundary conditions").sublist("concentration");
-  auto& src_list =
-    pks_list_->sublist(name_surf_).sublist("source terms").sublist("component mass source");
-
   Key ss_flux_key =
     Keys::readKey(pks_list_->sublist(name_ss_), domain_ss, "water flux", "water_flux");
   Key surf_flux_key =
     Keys::readKey(pks_list_->sublist(name_surf_), domain_surf, "water flux", "water_flux");
 
-  Key ss_tcc_key = Keys::readKey(pks_list_->sublist(name_ss_), domain_ss, "concentration");
-  Key surf_tcc_key = Keys::readKey(pks_list_->sublist(name_surf_), domain_surf, "concentration");
+  Key ss_tcc_key = Keys::readKey(
+    pks_list_->sublist(name_ss_), domain_ss, "concentration", "total_component_concentration");
+  Key surf_tcc_key = Keys::readKey(
+    pks_list_->sublist(name_surf_), domain_surf, "concentration", "total_component_concentration");
   Key surf_tcq_key = Keys::readKey(
     pks_list_->sublist(name_surf_), domain_surf, "conserved quantity", "total_component_quantity");
 
+  auto& bc_list =
+    pks_list_->sublist(name_ss_).sublist("boundary conditions").sublist("concentration");
   if (!bc_list.isSublist("BC coupling")) {
     Teuchos::ParameterList& bc_coupling = bc_list.sublist("BC coupling");
     bc_coupling.set<std::string>("spatial distribution method", "domain coupling");
@@ -62,6 +61,8 @@ MPCCoupledTransport::modifyParameterList()
     tmp.set<std::string>("external field copy key", tag_next_.get());
   }
 
+  auto& src_list =
+    pks_list_->sublist(name_surf_).sublist("source terms").sublist("component mass source");
   if (!src_list.isSublist("surface coupling")) {
     Teuchos::ParameterList& src_coupling = src_list.sublist("surface coupling");
     src_coupling.set<std::string>("spatial distribution method", "domain coupling");
@@ -79,7 +80,7 @@ MPCCoupledTransport::modifyParameterList()
     tmp.set<std::string>("external field copy key", tag_next_.get());
   }
 
-  WeakMPC::modifyParameterList();
+  WeakMPC::parseParameterList();
 }
 
 

--- a/src/pks/mpc/mpc_coupled_transport.hh
+++ b/src/pks/mpc/mpc_coupled_transport.hh
@@ -32,7 +32,7 @@ class MPCCoupledTransport : public WeakMPC {
                       const Teuchos::RCP<TreeVector>& soln);
 
   // PK methods
-  void modifyParameterList() override;
+  void parseParameterList() override;
   void Setup() override;
   int get_num_aqueous_component();
 

--- a/src/pks/mpc/mpc_coupled_transport.hh
+++ b/src/pks/mpc/mpc_coupled_transport.hh
@@ -32,7 +32,8 @@ class MPCCoupledTransport : public WeakMPC {
                       const Teuchos::RCP<TreeVector>& soln);
 
   // PK methods
-  virtual void Setup() override;
+  void modifyParameterList() override;
+  void Setup() override;
   int get_num_aqueous_component();
 
   // bug, see amanzi/ats#125

--- a/src/pks/mpc/mpc_coupled_water.cc
+++ b/src/pks/mpc/mpc_coupled_water.cc
@@ -26,7 +26,7 @@ MPCCoupledWater::MPCCoupledWater(Teuchos::ParameterList& pk_tree,
 {}
 
 void
-MPCCoupledWater::modifyParameterList()
+MPCCoupledWater::parseParameterList()
 {
   Teuchos::Array<std::string> names = plist_->get<Teuchos::Array<std::string>>("PKs order");
 
@@ -38,22 +38,14 @@ MPCCoupledWater::modifyParameterList()
   pks_list_->sublist(names[1]).sublist("diffusion preconditioner").set("surface operator", true);
   pks_list_->sublist(names[1]).sublist("accumulation preconditioner").set("surface operator", true);
 
-  StrongMPC<PK_PhysicalBDF_Default>::modifyParameterList();
-}
-
-
-void
-MPCCoupledWater::parseParameterList()
-{
-  StrongMPC<PK_PhysicalBDF_Default>::parseParameterList();
-
-  Teuchos::Array<std::string> names = plist_->get<Teuchos::Array<std::string>>("PKs order");
   domain_ss_ = pks_list_->sublist(names[0]).get<std::string>("domain name", "domain");
   domain_surf_ = pks_list_->sublist(names[1]).get<std::string>("domain name", "surface");
 
   // keys
   exfilt_key_ =
     Keys::readKey(*plist_, domain_surf_, "exfiltration flux", "surface_subsurface_flux");
+
+  StrongMPC<PK_PhysicalBDF_Default>::parseParameterList();
 }
 
 

--- a/src/pks/mpc/mpc_coupled_water.hh
+++ b/src/pks/mpc/mpc_coupled_water.hh
@@ -55,6 +55,10 @@ class MPCCoupledWater : public StrongMPC<PK_PhysicalBDF_Default> {
                   const Teuchos::RCP<State>& S,
                   const Teuchos::RCP<TreeVector>& soln);
 
+  // Parse the local parameter list and add entries to the global list
+  virtual void modifyParameterList() override;
+  virtual void parseParameterList() override;
+
   virtual void Setup() override;
   virtual void Initialize() override;
 

--- a/src/pks/mpc/mpc_coupled_water.hh
+++ b/src/pks/mpc/mpc_coupled_water.hh
@@ -56,7 +56,6 @@ class MPCCoupledWater : public StrongMPC<PK_PhysicalBDF_Default> {
                   const Teuchos::RCP<TreeVector>& soln);
 
   // Parse the local parameter list and add entries to the global list
-  virtual void modifyParameterList() override;
   virtual void parseParameterList() override;
 
   virtual void Setup() override;

--- a/src/pks/mpc/mpc_coupled_water_split_flux.cc
+++ b/src/pks/mpc/mpc_coupled_water_split_flux.cc
@@ -19,7 +19,14 @@ MPCCoupledWaterSplitFlux::MPCCoupledWaterSplitFlux(
   const Teuchos::RCP<State>& S,
   const Teuchos::RCP<TreeVector>& solution)
   : PK(FElist, plist, S, solution), MPCSubcycled(FElist, plist, S, solution)
+{}
+
+
+void
+MPCCoupledWaterSplitFlux::parseParameterList()
 {
+  MPCSubcycled::parseParameterList();
+
   // collect domain names
   domain_set_ = Keys::readDomain(*plist_);          // e.g. surface or surface_column:*
   domain_star_ = Keys::readDomain(*plist_, "star"); // e.g. surface_star
@@ -68,6 +75,8 @@ MPCCoupledWaterSplitFlux::MPCCoupledWaterSplitFlux(
     p_lateral_flow_source_ =
       Keys::readKey(*plist_, domain_, "water lateral flow source", "water_lateral_flow_source");
     p_lateral_flow_source_suffix_ = Keys::getVarName(p_lateral_flow_source_);
+    S_->GetEvaluatorList(p_lateral_flow_source_).set("evaluator type", "primary variable");
+
     cv_key_ = Keys::readKey(*plist_, domain_star_, "cell volume", "cell_volume");
   }
 };

--- a/src/pks/mpc/mpc_coupled_water_split_flux.hh
+++ b/src/pks/mpc/mpc_coupled_water_split_flux.hh
@@ -63,6 +63,8 @@ class MPCCoupledWaterSplitFlux : public MPCSubcycled {
                            const Teuchos::RCP<TreeVector>& solution);
 
   // PK methods
+  void parseParameterList() override;
+
   // -- initialize in reverse order
   virtual void Initialize() override;
   virtual void Setup() override;

--- a/src/pks/mpc/mpc_permafrost.cc
+++ b/src/pks/mpc/mpc_permafrost.cc
@@ -62,6 +62,15 @@ MPCPermafrost::modifyParameterList()
   pks_list_->sublist(names[3]).sublist("advection preconditioner").set("surface operator", true);
   pks_list_->sublist(names[3]).sublist("accumulation preconditioner").set("surface operator", true);
 
+  // -- primary exchange flux keys and evaluators
+  mass_exchange_key_ =
+    Keys::readKey(*plist_, domain_surf_, "mass exchange flux", "surface_subsurface_flux");
+  S_->GetEvaluatorList(mass_exchange_key_).set("evaluator type", "primary variable");
+
+  energy_exchange_key_ =
+    Keys::readKey(*plist_, domain_surf_, "energy exchange flux", "surface_subsurface_energy_flux");
+  S_->GetEvaluatorList(energy_exchange_key_).set("evaluator type", "primary variable");
+
   MPCSubsurface::modifyParameterList();
 }
 
@@ -70,12 +79,7 @@ MPCPermafrost::parseParameterList()
 {
   MPCSubsurface::parseParameterList();
 
-  // exchange flux keys and evaluators
-  mass_exchange_key_ =
-    Keys::readKey(*plist_, domain_surf_, "mass exchange flux", "surface_subsurface_flux");
-  energy_exchange_key_ =
-    Keys::readKey(*plist_, domain_surf_, "energy exchange flux", "surface_subsurface_energy_flux");
-
+  // parse keys
   surf_temp_key_ = Keys::readKey(*plist_, domain_surf_, "surface temperature", "temperature");
   surf_pres_key_ = Keys::readKey(*plist_, domain_surf_, "surface pressure", "pressure");
   surf_e_key_ = Keys::readKey(*plist_, domain_surf_, "surface energy", "energy");

--- a/src/pks/mpc/mpc_permafrost.hh
+++ b/src/pks/mpc/mpc_permafrost.hh
@@ -53,6 +53,11 @@ class MPCPermafrost : public MPCSubsurface {
                 const Teuchos::RCP<State>& S,
                 const Teuchos::RCP<TreeVector>& soln);
 
+  // call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() override;
+
+  // read said list
+  virtual void parseParameterList() override;
 
   virtual void set_tags(const Tag& tag_current, const Tag& tag_next) override;
 

--- a/src/pks/mpc/mpc_permafrost.hh
+++ b/src/pks/mpc/mpc_permafrost.hh
@@ -54,9 +54,6 @@ class MPCPermafrost : public MPCSubsurface {
                 const Teuchos::RCP<TreeVector>& soln);
 
   // call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() override;
-
-  // read said list
   virtual void parseParameterList() override;
 
   virtual void set_tags(const Tag& tag_current, const Tag& tag_next) override;

--- a/src/pks/mpc/mpc_permafrost_split_flux.hh
+++ b/src/pks/mpc/mpc_permafrost_split_flux.hh
@@ -75,10 +75,7 @@ class MPCPermafrostSplitFlux : public MPCSubcycled {
                          const Teuchos::RCP<TreeVector>& solution);
 
   // PK methods
-  // -- call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() override;
-
-  // -- read said list
+  // -- read input plist
   virtual void parseParameterList() override;
 
   // -- initialize in reverse order

--- a/src/pks/mpc/mpc_permafrost_split_flux.hh
+++ b/src/pks/mpc/mpc_permafrost_split_flux.hh
@@ -75,6 +75,12 @@ class MPCPermafrostSplitFlux : public MPCSubcycled {
                          const Teuchos::RCP<TreeVector>& solution);
 
   // PK methods
+  // -- call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() override;
+
+  // -- read said list
+  virtual void parseParameterList() override;
+
   // -- initialize in reverse order
   virtual void Initialize() override;
   virtual void Setup() override;

--- a/src/pks/mpc/mpc_subcycled.cc
+++ b/src/pks/mpc/mpc_subcycled.cc
@@ -27,6 +27,8 @@ MPCSubcycled::MPCSubcycled(Teuchos::ParameterList& pk_tree,
 {
   init_();
 
+  // NOTE: this must be done prior to set_tags(), therefore before even parseParameterList()
+  //
   // Master PK is the PK whose time step size sets the size, the subcycled is subcycled.
   subcycling_ = plist_->get<Teuchos::Array<int>>("subcycle");
   if (subcycling_.size() != sub_pks_.size()) {
@@ -35,6 +37,12 @@ MPCSubcycled::MPCSubcycled(Teuchos::ParameterList& pk_tree,
     Exceptions::amanzi_throw(msg);
   }
   dts_.resize(sub_pks_.size(), -1);
+}
+
+void
+MPCSubcycled::parseParameterList()
+{
+  MPC<PK>::parseParameterList();
 
   // min dt allowed in subcycling
   target_dt_ = plist_->get<double>("subcycling target time step [s]", -1);

--- a/src/pks/mpc/mpc_subcycled.hh
+++ b/src/pks/mpc/mpc_subcycled.hh
@@ -36,17 +36,19 @@ class MPCSubcycled : public MPC<PK> {
                const Teuchos::RCP<TreeVector>& soln);
 
   // PK methods
-  // -- dt is the minimum of the sub pks
-  virtual double get_dt() override;
-  virtual void set_dt(double dt) override;
-  virtual void set_tags(const Tag& current, const Tag& next) override;
+  void parseParameterList() override;
 
-  virtual void Setup() override;
-  virtual void Initialize() override;
+  // -- dt is the minimum of the sub pks
+  double get_dt() override;
+  void set_dt(double dt) override;
+  void set_tags(const Tag& current, const Tag& next) override;
+
+  void Setup() override;
+  void Initialize() override;
 
   // -- advance each sub pk dt.
-  virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false) override;
-  virtual void CommitStep(double t_old, double t_new, const Tag& tag) override;
+  bool AdvanceStep(double t_old, double t_new, bool reinit = false) override;
+  void CommitStep(double t_old, double t_new, const Tag& tag) override;
 
  protected:
   // advance the ith sub_pk

--- a/src/pks/mpc/mpc_subsurface.cc
+++ b/src/pks/mpc/mpc_subsurface.cc
@@ -42,7 +42,14 @@ MPCSubsurface::MPCSubsurface(Teuchos::ParameterList& pk_tree_list,
   : PK(pk_tree_list, global_list, S, soln),
     StrongMPC<PK_PhysicalBDF_Default>(pk_tree_list, global_list, S, soln),
     update_pcs_(0)
+{}
+
+
+void
+MPCSubsurface::parseParameterList()
 {
+  StrongMPC<PK_PhysicalBDF_Default>::parseParameterList();
+
   // set up keys
   dump_ = plist_->get<bool>("dump preconditioner", false);
   domain_name_ = plist_->get<std::string>("domain name", "domain");

--- a/src/pks/mpc/mpc_subsurface.hh
+++ b/src/pks/mpc/mpc_subsurface.hh
@@ -164,6 +164,10 @@ class MPCSubsurface : public StrongMPC<PK_PhysicalBDF_Default> {
                 const Teuchos::RCP<State>& S,
                 const Teuchos::RCP<TreeVector>& soln);
 
+  // read said list
+  virtual void parseParameterList() override;
+
+
   // -- Initialize owned (dependent) variables.
   virtual void Setup() override;
   virtual void Initialize() override;

--- a/src/pks/mpc/mpc_surface.cc
+++ b/src/pks/mpc/mpc_surface.cc
@@ -40,7 +40,13 @@ MPCSurface::MPCSurface(Teuchos::ParameterList& pk_tree_list,
                        const Teuchos::RCP<TreeVector>& soln)
   : PK(pk_tree_list, global_list, S, soln),
     StrongMPC<PK_PhysicalBDF_Default>(pk_tree_list, global_list, S, soln)
+{}
+
+void
+MPCSurface::parseParameterList()
 {
+  StrongMPC<PK_PhysicalBDF_Default>::parseParameterList();
+
   auto pk_order = plist_->get<Teuchos::Array<std::string>>("PKs order");
   domain_ = plist_->get<std::string>("domain name");
 

--- a/src/pks/mpc/mpc_surface.hh
+++ b/src/pks/mpc/mpc_surface.hh
@@ -40,7 +40,7 @@ class MPCSurface : public StrongMPC<PK_PhysicalBDF_Default> {
              const Teuchos::RCP<State>& S,
              const Teuchos::RCP<TreeVector>& soln);
 
-  // -- Initialize owned (dependent) variables.
+  void parseParameterList() override;
   virtual void Setup() override;
   virtual void Initialize() override;
   //virtual void set_tags(const Tag& tag_current, const Tag& tag_next);

--- a/src/pks/mpc/mpc_weak_subdomain.cc
+++ b/src/pks/mpc/mpc_weak_subdomain.cc
@@ -37,8 +37,15 @@ MPCWeakSubdomain::MPCWeakSubdomain(Teuchos::ParameterList& FElist,
 {
   init_();
 
-  // check whether we are subcycling
+  // check whether we are subcycling -- note this must be known prior to set_tags()
   internal_subcycling_ = plist_->template get<bool>("subcycle", false);
+}
+
+void
+MPCWeakSubdomain::parseParameterList()
+{
+  MPC<PK>::parseParameterList();
+
   if (internal_subcycling_) {
     internal_subcycling_target_dt_ =
       plist_->template get<double>("subcycling target time step [s]");

--- a/src/pks/mpc/mpc_weak_subdomain.hh
+++ b/src/pks/mpc/mpc_weak_subdomain.hh
@@ -29,17 +29,19 @@ class MPCWeakSubdomain : public MPC<PK> {
                    const Teuchos::RCP<TreeVector>& solution);
 
   // PK methods
-  // -- dt is the minimum of the sub pks
-  virtual double get_dt() override;
-  virtual void set_dt(double dt) override;
-  virtual void set_tags(const Tag& current, const Tag& next) override;
+  void parseParameterList() override;
 
-  virtual void Setup() override;
-  virtual void Initialize() override;
+  // -- dt is the minimum of the sub pks
+  double get_dt() override;
+  void set_dt(double dt) override;
+  void set_tags(const Tag& current, const Tag& next) override;
+
+  void Setup() override;
+  void Initialize() override;
 
   // -- advance each sub pk dt.
-  virtual bool AdvanceStep(double t_old, double t_new, bool reinit) override;
-  virtual void CommitStep(double t_old, double t_new, const Tag& tag_next) override;
+  bool AdvanceStep(double t_old, double t_new, bool reinit) override;
+  void CommitStep(double t_old, double t_new, const Tag& tag_next) override;
 
  protected:
   void init_();

--- a/src/pks/mpc/strong_mpc.hh
+++ b/src/pks/mpc/strong_mpc.hh
@@ -42,7 +42,7 @@ class StrongMPC : public MPC<PK_t>, public PK_BDF_Default {
             const Teuchos::RCP<State>& S,
             const Teuchos::RCP<TreeVector>& solution);
 
-  virtual void modifyParameterList() override;
+  virtual void parseParameterList() override;
 
   //
   // These methods override methods in MPC<PK_t>
@@ -134,7 +134,7 @@ StrongMPC<PK_t>::StrongMPC(Teuchos::ParameterList& pk_tree,
 
 template <class PK_t>
 void
-StrongMPC<PK_t>::modifyParameterList()
+StrongMPC<PK_t>::parseParameterList()
 {
   // push on a parameter to indicate that sub-pks need not assemble their
   // operators, as we will do that here (or above here)
@@ -143,8 +143,8 @@ StrongMPC<PK_t>::modifyParameterList()
     pks_list_->sublist(pk_name).set("strongly coupled PK", true);
   }
 
-  PK_BDF_Default::modifyParameterList();
-  MPC<PK_t>::modifyParameterList();
+  PK_BDF_Default::parseParameterList();
+  MPC<PK_t>::parseParameterList();
 }
 
 

--- a/src/pks/mpc/strong_mpc.hh
+++ b/src/pks/mpc/strong_mpc.hh
@@ -42,6 +42,8 @@ class StrongMPC : public MPC<PK_t>, public PK_BDF_Default {
             const Teuchos::RCP<State>& S,
             const Teuchos::RCP<TreeVector>& solution);
 
+  virtual void modifyParameterList() override;
+
   //
   // These methods override methods in MPC<PK_t>
   // -----------------------------------------------------------------------------
@@ -126,6 +128,23 @@ StrongMPC<PK_t>::StrongMPC(Teuchos::ParameterList& pk_tree,
     PK_BDF_Default(pk_tree, global_list, S, soln)
 {
   MPC<PK_t>::init_(soln->Comm());
+}
+
+
+
+template <class PK_t>
+void
+StrongMPC<PK_t>::modifyParameterList()
+{
+  // push on a parameter to indicate that sub-pks need not assemble their
+  // operators, as we will do that here (or above here)
+  auto pk_order = plist_->template get<Teuchos::Array<std::string>>("PKs order");
+  for (const auto& pk_name : pk_order) {
+    pks_list_->sublist(pk_name).set("strongly coupled PK", true);
+  }
+
+  PK_BDF_Default::modifyParameterList();
+  MPC<PK_t>::modifyParameterList();
 }
 
 

--- a/src/pks/pk_physical_bdf_default.cc
+++ b/src/pks/pk_physical_bdf_default.cc
@@ -19,6 +19,17 @@ PKPhysicalBase and BDF methods of PK_BDF_Default.
 
 namespace Amanzi {
 
+void
+PK_PhysicalBDF_Default::parseParameterList()
+{
+  conserved_key_ = Keys::readKey(*plist_, domain_, "conserved quantity");
+  atol_ = plist_->get<double>("absolute error tolerance", 1.0);
+  rtol_ = plist_->get<double>("relative error tolerance", 1.0);
+  fluxtol_ = plist_->get<double>("flux error tolerance", 1.0);
+
+  cell_vol_key_ = Keys::readKey(*plist_, domain_, "cell volume", "cell_volume");
+}
+
 // -----------------------------------------------------------------------------
 // Setup
 // -----------------------------------------------------------------------------
@@ -34,9 +45,6 @@ PK_PhysicalBDF_Default::Setup()
     new Operators::BCs(mesh_, AmanziMesh::Entity_kind::FACE, WhetStone::DOF_Type::SCALAR));
 
   // convergence criteria is based on a conserved quantity
-  if (conserved_key_.empty()) {
-    conserved_key_ = Keys::readKey(*plist_, domain_, "conserved quantity");
-  }
   requireAtNext(conserved_key_, tag_next_, *S_)
     .SetMesh(mesh_)
     ->SetGhosted()
@@ -45,16 +53,9 @@ PK_PhysicalBDF_Default::Setup()
   requireAtCurrent(conserved_key_, tag_current_, *S_, name_, true);
 
   // cell volume used throughout
-  if (cell_vol_key_.empty()) {
-    cell_vol_key_ = Keys::readKey(*plist_, domain_, "cell volume", "cell_volume");
-  }
   requireAtNext(cell_vol_key_, tag_next_, *S_)
     .SetMesh(mesh_)
     ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, true);
-
-  atol_ = plist_->get<double>("absolute error tolerance", 1.0);
-  rtol_ = plist_->get<double>("relative error tolerance", 1.0);
-  fluxtol_ = plist_->get<double>("flux error tolerance", 1.0);
 };
 
 

--- a/src/pks/pk_physical_bdf_default.cc
+++ b/src/pks/pk_physical_bdf_default.cc
@@ -22,6 +22,9 @@ namespace Amanzi {
 void
 PK_PhysicalBDF_Default::parseParameterList()
 {
+  PK_BDF_Default::parseParameterList();
+  PK_Physical_Default::parseParameterList();
+
   conserved_key_ = Keys::readKey(*plist_, domain_, "conserved quantity");
   atol_ = plist_->get<double>("absolute error tolerance", 1.0);
   rtol_ = plist_->get<double>("relative error tolerance", 1.0);

--- a/src/pks/pk_physical_bdf_default.hh
+++ b/src/pks/pk_physical_bdf_default.hh
@@ -75,6 +75,8 @@ class PK_PhysicalBDF_Default : public PK_BDF_Default, public PK_Physical_Default
       PK_Physical_Default(pk_tree, glist, S, solution)
   {}
 
+  virtual void parseParameterList() override;
+
   virtual void Setup() override;
 
   // initialize.  Note both BDFBase and PhysicalBase have initialize()

--- a/src/pks/pk_physical_default.cc
+++ b/src/pks/pk_physical_default.cc
@@ -30,22 +30,17 @@ PK_Physical_Default::PK_Physical_Default(Teuchos::ParameterList& pk_tree,
 {}
 
 void
-PK_Physical_Default::modifyParameterList()
-{
-  key_ = Keys::readKey(*plist_, domain_, "primary variable");
-  Teuchos::ParameterList& plist = S_->GetEvaluatorList(key_);
-  plist.set("evaluator type", "primary variable");
-
-  PK_Physical::modifyParameterList();
-}
-
-void
 PK_Physical_Default::parseParameterList()
 {
-  PK_Physical::parseParameterList();
+  // require primary variable evaluators
+  key_ = Keys::readKey(*plist_, domain_, "primary variable");
+  requireAtNext(key_, tag_next_, *S_, name_);
+  requireAtCurrent(key_, tag_current_, *S_, name_);
 
   // primary variable max change
   max_valid_change_ = plist_->get<double>("max valid change", -1.0);
+
+  PK_Physical::parseParameterList();
 }
 
 
@@ -56,9 +51,6 @@ PK_Physical_Default::parseParameterList()
 void
 PK_Physical_Default::Setup()
 {
-  // get the mesh
-  mesh_ = S_->GetMesh(domain_);
-
   // set up the debugger
   Teuchos::RCP<Teuchos::ParameterList> vo_plist = plist_;
   if (plist_->isSublist(name_ + " verbose object")) {
@@ -67,10 +59,6 @@ PK_Physical_Default::Setup()
   }
 
   db_ = Teuchos::rcp(new Debugger(mesh_, name_, *vo_plist));
-
-  // require primary variable evaluators
-  requireAtNext(key_, tag_next_, *S_, name_);
-  requireAtCurrent(key_, tag_current_, *S_, name_);
 };
 
 

--- a/src/pks/pk_physical_default.cc
+++ b/src/pks/pk_physical_default.cc
@@ -32,6 +32,14 @@ PK_Physical_Default::PK_Physical_Default(Teuchos::ParameterList& pk_tree,
   max_valid_change_ = plist_->get<double>("max valid change", -1.0);
 }
 
+void
+PK_Physical_Default::modifyParameterList()
+{
+  Teuchos::ParameterList& plist = S_->GetEvaluatorList(key_);
+  plist.set("evaluator type", "primary variable");
+}
+
+
 // -----------------------------------------------------------------------------
 // Construction of data.
 // -----------------------------------------------------------------------------

--- a/src/pks/pk_physical_default.cc
+++ b/src/pks/pk_physical_default.cc
@@ -24,19 +24,28 @@ PK_Physical_Default::PK_Physical_Default(Teuchos::ParameterList& pk_tree,
                                          const Teuchos::RCP<Teuchos::ParameterList>& glist,
                                          const Teuchos::RCP<State>& S,
                                          const Teuchos::RCP<TreeVector>& solution)
-  : PK(pk_tree, glist, S, solution), PK_Physical(pk_tree, glist, S, solution)
-{
-  key_ = Keys::readKey(*plist_, domain_, "primary variable");
-
-  // primary variable max change
-  max_valid_change_ = plist_->get<double>("max valid change", -1.0);
-}
+  : PK(pk_tree, glist, S, solution),
+    PK_Physical(pk_tree, glist, S, solution),
+    max_valid_change_(-1.0)
+{}
 
 void
 PK_Physical_Default::modifyParameterList()
 {
+  key_ = Keys::readKey(*plist_, domain_, "primary variable");
   Teuchos::ParameterList& plist = S_->GetEvaluatorList(key_);
   plist.set("evaluator type", "primary variable");
+
+  PK_Physical::modifyParameterList();
+}
+
+void
+PK_Physical_Default::parseParameterList()
+{
+  PK_Physical::parseParameterList();
+
+  // primary variable max change
+  max_valid_change_ = plist_->get<double>("max valid change", -1.0);
 }
 
 

--- a/src/pks/pk_physical_default.hh
+++ b/src/pks/pk_physical_default.hh
@@ -60,6 +60,7 @@ class PK_Physical_Default : public PK_Physical {
   virtual ~PK_Physical_Default() = default;
 
   virtual void modifyParameterList() override;
+  virtual void parseParameterList() override;
   virtual bool ValidStep() override;
 
   // Tag the primary variable as changed in the DAG

--- a/src/pks/pk_physical_default.hh
+++ b/src/pks/pk_physical_default.hh
@@ -59,7 +59,6 @@ class PK_Physical_Default : public PK_Physical {
   // Virtual destructor
   virtual ~PK_Physical_Default() = default;
 
-  virtual void modifyParameterList() override;
   virtual void parseParameterList() override;
   virtual bool ValidStep() override;
 

--- a/src/pks/pk_physical_default.hh
+++ b/src/pks/pk_physical_default.hh
@@ -59,6 +59,7 @@ class PK_Physical_Default : public PK_Physical {
   // Virtual destructor
   virtual ~PK_Physical_Default() = default;
 
+  virtual void modifyParameterList() override;
   virtual bool ValidStep() override;
 
   // Tag the primary variable as changed in the DAG

--- a/src/pks/surface_balance/surface_balance_base.cc
+++ b/src/pks/surface_balance/surface_balance_base.cc
@@ -20,7 +20,25 @@ SurfaceBalanceBase::SurfaceBalanceBase(Teuchos::ParameterList& pk_tree,
                                        const Teuchos::RCP<State>& S,
                                        const Teuchos::RCP<TreeVector>& solution)
   : PK(pk_tree, global_list, S, solution), PK_PhysicalBDF_Default(pk_tree, global_list, S, solution)
+{}
+
+
+void
+SurfaceBalanceBase::modifyParameterList()
 {
+  // set a default absolute tolerance
+  if (!plist_->isParameter("absolute error tolerance"))
+    plist_->set("absolute error tolerance", .01 * 55000.); // h * nl
+
+  PK_PhysicalBDF_Default::modifyParameterList();
+}
+
+
+void
+SurfaceBalanceBase::parseParameterList()
+{
+  PK_PhysicalBDF_Default::parseParameterList();
+
   // source terms
   eps_ = plist_->get<double>("source term finite difference epsilon", 1.e-8);
   is_source_ = plist_->get<bool>("source term", true);
@@ -39,10 +57,6 @@ SurfaceBalanceBase::SurfaceBalanceBase(Teuchos::ParameterList& pk_tree,
       "SurfaceBalanceBase: \"time discretization theta\" value must be between 0 and 1.");
     Exceptions::amanzi_throw(message);
   }
-
-  // set a default absolute tolerance
-  if (!plist_->isParameter("absolute error tolerance"))
-    plist_->set("absolute error tolerance", .01 * 55000.); // h * nl
 }
 
 

--- a/src/pks/surface_balance/surface_balance_base.cc
+++ b/src/pks/surface_balance/surface_balance_base.cc
@@ -19,7 +19,11 @@ SurfaceBalanceBase::SurfaceBalanceBase(Teuchos::ParameterList& pk_tree,
                                        const Teuchos::RCP<Teuchos::ParameterList>& global_list,
                                        const Teuchos::RCP<State>& S,
                                        const Teuchos::RCP<TreeVector>& solution)
-  : PK(pk_tree, global_list, S, solution), PK_PhysicalBDF_Default(pk_tree, global_list, S, solution)
+  : PK(pk_tree, global_list, S, solution),
+    PK_PhysicalBDF_Default(pk_tree, global_list, S, solution),
+    is_source_term_(false),
+    is_source_term_differentiable_(false),
+    is_source_term_finite_differentiable_(false)
 {}
 
 

--- a/src/pks/surface_balance/surface_balance_base.cc
+++ b/src/pks/surface_balance/surface_balance_base.cc
@@ -24,19 +24,12 @@ SurfaceBalanceBase::SurfaceBalanceBase(Teuchos::ParameterList& pk_tree,
 
 
 void
-SurfaceBalanceBase::modifyParameterList()
+SurfaceBalanceBase::parseParameterList()
 {
   // set a default absolute tolerance
   if (!plist_->isParameter("absolute error tolerance"))
     plist_->set("absolute error tolerance", .01 * 55000.); // h * nl
 
-  PK_PhysicalBDF_Default::modifyParameterList();
-}
-
-
-void
-SurfaceBalanceBase::parseParameterList()
-{
   PK_PhysicalBDF_Default::parseParameterList();
 
   // source terms

--- a/src/pks/surface_balance/surface_balance_base.hh
+++ b/src/pks/surface_balance/surface_balance_base.hh
@@ -63,6 +63,9 @@ class SurfaceBalanceBase : public PK_PhysicalBDF_Default {
                      const Teuchos::RCP<State>& S,
                      const Teuchos::RCP<TreeVector>& solution);
 
+  virtual void parseParameterList() override;
+  virtual void modifyParameterList() override;
+
   // main methods
   // -- Setup data.
   virtual void Setup() override;

--- a/src/pks/surface_balance/surface_balance_base.hh
+++ b/src/pks/surface_balance/surface_balance_base.hh
@@ -92,7 +92,9 @@ class SurfaceBalanceBase : public PK_PhysicalBDF_Default {
 
  protected:
   bool conserved_quantity_;
-  bool is_source_, is_source_differentiable_, source_finite_difference_;
+  bool is_source_term_;
+  bool is_source_term_differentiable_;
+  bool is_source_term_finite_differentiable_;
   Key source_key_;
 
   double theta_;

--- a/src/pks/surface_balance/surface_balance_base.hh
+++ b/src/pks/surface_balance/surface_balance_base.hh
@@ -64,7 +64,6 @@ class SurfaceBalanceBase : public PK_PhysicalBDF_Default {
                      const Teuchos::RCP<TreeVector>& solution);
 
   virtual void parseParameterList() override;
-  virtual void modifyParameterList() override;
 
   // main methods
   // -- Setup data.

--- a/src/pks/surface_balance/surface_balance_implicit_subgrid.cc
+++ b/src/pks/surface_balance/surface_balance_implicit_subgrid.cc
@@ -35,32 +35,24 @@ ImplicitSubgrid::ImplicitSubgrid(Teuchos::ParameterList& pk_tree,
 {}
 
 void
-ImplicitSubgrid::modifyParameterList()
+ImplicitSubgrid::parseParameterList()
 {
   // set the error tolerance for snow
   plist_->set("absolute error tolerance", 0.01);
 
   snow_dens_key_ = Keys::readKey(*plist_, domain_, "snow density", "density");
-  S_->GetEvaluatorList(snow_dens_key_).set("evaluator type", "primary variable");
+  requireAtNext(snow_dens_key_, tag_next_, *S_, name_);
 
   snow_death_rate_key_ = Keys::readKey(*plist_, domain_, "snow death rate", "death_rate");
-  S_->GetEvaluatorList(snow_death_rate_key_).set("evaluator type", "primary variable");
+  requireAtNext(snow_death_rate_key_, tag_next_, *S_, name_);
 
   snow_age_key_ = Keys::readKey(*plist_, domain_, "snow age", "age");
-  S_->GetEvaluatorList(snow_age_key_).set("evaluator type", "primary variable");
-
-  SurfaceBalanceBase::modifyParameterList();
-}
-
-
-void
-ImplicitSubgrid::parseParameterList()
-{
-  SurfaceBalanceBase::parseParameterList();
+  requireAtNext(snow_age_key_, tag_next_, *S_, name_);
 
   new_snow_key_ = Keys::readKey(*plist_, domain_, "new snow source", "source");
-
   density_snow_max_ = plist_->get<double>("max density of snow [kg m^-3]", 600.);
+
+  SurfaceBalanceBase::parseParameterList();
 }
 
 // main methods

--- a/src/pks/surface_balance/surface_balance_implicit_subgrid.cc
+++ b/src/pks/surface_balance/surface_balance_implicit_subgrid.cc
@@ -32,21 +32,35 @@ ImplicitSubgrid::ImplicitSubgrid(Teuchos::ParameterList& pk_tree,
                                  const Teuchos::RCP<State>& S,
                                  const Teuchos::RCP<TreeVector>& solution)
   : PK(pk_tree, global_list, S, solution), SurfaceBalanceBase(pk_tree, global_list, S, solution)
+{}
+
+void
+ImplicitSubgrid::modifyParameterList()
 {
-  if (!plist_->isParameter("conserved quantity key suffix"))
-    plist_->set("conserved quantity key suffix", "snow_water_equivalent");
-
-  // set up keys
-  Key domain_surf = Keys::readDomainHint(*plist_, domain_, "snow", "surface");
-  snow_dens_key_ = Keys::readKey(*plist_, domain_, "snow density", "density");
-  snow_age_key_ = Keys::readKey(*plist_, domain_, "snow age", "age");
-  new_snow_key_ = Keys::readKey(*plist_, domain_, "new snow source", "source");
-  snow_death_rate_key_ = Keys::readKey(*plist_, domain_, "snow death rate", "death_rate");
-
-  density_snow_max_ = plist_->get<double>("max density of snow [kg m^-3]", 600.);
-
   // set the error tolerance for snow
   plist_->set("absolute error tolerance", 0.01);
+
+  snow_dens_key_ = Keys::readKey(*plist_, domain_, "snow density", "density");
+  S_->GetEvaluatorList(snow_dens_key_).set("evaluator type", "primary variable");
+
+  snow_death_rate_key_ = Keys::readKey(*plist_, domain_, "snow death rate", "death_rate");
+  S_->GetEvaluatorList(snow_death_rate_key_).set("evaluator type", "primary variable");
+
+  snow_age_key_ = Keys::readKey(*plist_, domain_, "snow age", "age");
+  S_->GetEvaluatorList(snow_age_key_).set("evaluator type", "primary variable");
+
+  SurfaceBalanceBase::modifyParameterList();
+}
+
+
+void
+ImplicitSubgrid::parseParameterList()
+{
+  SurfaceBalanceBase::parseParameterList();
+
+  new_snow_key_ = Keys::readKey(*plist_, domain_, "new snow source", "source");
+
+  density_snow_max_ = plist_->get<double>("max density of snow [kg m^-3]", 600.);
 }
 
 // main methods

--- a/src/pks/surface_balance/surface_balance_implicit_subgrid.hh
+++ b/src/pks/surface_balance/surface_balance_implicit_subgrid.hh
@@ -62,9 +62,6 @@ class ImplicitSubgrid : public SurfaceBalanceBase {
                   const Teuchos::RCP<TreeVector>& solution);
 
   // call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() override;
-
-  // read said list
   virtual void parseParameterList() override;
 
   // main methods

--- a/src/pks/surface_balance/surface_balance_implicit_subgrid.hh
+++ b/src/pks/surface_balance/surface_balance_implicit_subgrid.hh
@@ -61,6 +61,12 @@ class ImplicitSubgrid : public SurfaceBalanceBase {
                   const Teuchos::RCP<State>& S,
                   const Teuchos::RCP<TreeVector>& solution);
 
+  // call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() override;
+
+  // read said list
+  virtual void parseParameterList() override;
+
   // main methods
   // -- Setup data.
   virtual void Setup() override;

--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -304,6 +304,8 @@ class Transport_ATS : public PK_PhysicalExplicit<Epetra_Vector> {
 
   ~Transport_ATS() = default;
 
+  void parseParameterList() override;
+
   // members required by PK interface
   virtual void Setup() override;
 

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -442,7 +442,6 @@ Transport_ATS::SetupTransport_()
         std::string bc_type = bc_list.get<std::string>("spatial distribution method", "none");
 
         if (bc_type == "domain coupling") {
-          // See amanzi ticket #646 -- this should probably be tag_current_?
           // domain couplings are special -- they always work on all components
           Teuchos::RCP<TransportDomainFunction> bc =
             factory.Create(bc_list, "fields", AmanziMesh::Entity_kind::FACE, Kxy_, tag_current_);
@@ -462,7 +461,6 @@ Transport_ATS::SetupTransport_()
           int gid = std::stoi(domain_.substr(last_of + 1, domain_.size()));
           bc_list.set("entity_gid_out", gid);
 
-          // See amanzi ticket #646 -- this should probably be tag_current_?
           Teuchos::RCP<TransportDomainFunction> bc = factory.Create(
             bc_list, "boundary concentration", AmanziMesh::Entity_kind::FACE, Kxy_, tag_current_);
 
@@ -474,7 +472,6 @@ Transport_ATS::SetupTransport_()
           bcs_.push_back(bc);
 
         } else {
-          // See amanzi ticket #646 -- this should probably be tag_current_?
           Teuchos::RCP<TransportDomainFunction> bc =
             factory.Create(bc_list,
                            "boundary concentration function",

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -67,6 +67,15 @@ Transport_ATS::Transport_ATS(Teuchos::ParameterList& pk_tree,
     current_component_(-1),
     flag_dispersion_(false)
 {
+  // initialize io
+  units_.Init(global_plist->sublist("units"));
+}
+
+void
+Transport_ATS::parseParameterList()
+{
+  PK_PhysicalExplicit<Epetra_Vector>::parseParameterList();
+
   if (plist_->isParameter("component molar masses")) {
     mol_masses_ = plist_->get<Teuchos::Array<double>>("component molar masses").toVector();
   } else {
@@ -74,14 +83,15 @@ Transport_ATS::Transport_ATS(Teuchos::ParameterList& pk_tree,
     Exceptions::amanzi_throw(msg);
   }
 
-  // initialize io
-  units_.Init(global_plist->sublist("units"));
+  // primary variable
+  tcc_key_ = Keys::readKey(*plist_, domain_, "concentration", "total_component_concentration");
+  requireAtNext(tcc_key_, tag_next_, *S_, passwd_);
+  requireAtCurrent(tcc_key_, tag_current_, *S_, passwd_);
 
   // keys, dependencies, etc
   saturation_key_ = Keys::readKey(*plist_, domain_, "saturation liquid", "saturation_liquid");
   flux_key_ = Keys::readKey(*plist_, domain_, "water flux", "water_flux");
   permeability_key_ = Keys::readKey(*plist_, domain_, "permeability", "permeability");
-  tcc_key_ = Keys::readKey(*plist_, domain_, "concentration", "total_component_concentration");
   conserve_qty_key_ =
     Keys::readKey(*plist_, domain_, "conserved quantity", "total_component_quantity");
   porosity_key_ = Keys::readKey(*plist_, domain_, "porosity", "porosity");


### PR DESCRIPTION
This creates another level of setup, called parseParameterList(), that occurs after PK construction but before Setup.  Most ATS PKs constructor contents are now moved into parseParameterList(), and all PKs are modified to have them set their primary variables in this call.  This allows the key advancement that calling `State::SetEvaluator(key, tag, eval)` (the function that is called inside of `RequireEvaluator(...)` after construction) can now call `eval->EnsureEvaluators()`.  This means that the DAG is now valid as soon as the evaluator is set.  This allows some important changes to the use of the dag, e.g. calling `Evaluator::IsDifferentiableWRT()` immediately after calling `RequireEvaluator()`.

This PR closes #167
