### PR TITLE
Add conditional to select correct regression tests when --disable-geochemistry

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -17,9 +17,15 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ats-regression-tests/README.md")
   # figure out what tests are available
   if (ENABLE_Regression_Tests)
     set(ats_available_tests_string "")
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} ${ATS_REGRESSION_TESTS_DIR}/regression_tests.py --suites=testing --ats=${ATS_SOURCE_DIR} --list-tests .
-      OUTPUT_VARIABLE ats_available_tests_string
-      WORKING_DIRECTORY ${ATS_REGRESSION_TESTS_DIR})
+    if (ENABLE_GEOCHEMISTRY)
+      execute_process(COMMAND ${PYTHON_EXECUTABLE} ${ATS_REGRESSION_TESTS_DIR}/regression_tests.py --suites=testing --ats=${ATS_SOURCE_DIR} --list-tests .
+        OUTPUT_VARIABLE ats_available_tests_string
+        WORKING_DIRECTORY ${ATS_REGRESSION_TESTS_DIR})
+    else()
+      execute_process(COMMAND ${PYTHON_EXECUTABLE} ${ATS_REGRESSION_TESTS_DIR}/regression_tests.py --suites=testing_no_geochemistry --ats=${ATS_SOURCE_DIR} --list-tests .
+        OUTPUT_VARIABLE ats_available_tests_string
+        WORKING_DIRECTORY ${ATS_REGRESSION_TESTS_DIR})
+    endif()
 
     message("-- Found ATS tests:")
     string(STRIP ${ats_available_tests_string} ats_available_tests_string)


### PR DESCRIPTION
Add conditional to CMakeLists to use the testing_no_geochemistry suite when built with --disable-geochemistry in bootstrap. 

New branch of conditional not exercised in CI, but seemed to work in a local test.

Ref #248 