### PR TITLE
Add Observations for Advective and Diffusive Solute Mass Flux

### DIFF
--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -287,10 +287,12 @@ class Transport_ATS : public PK_Physical_Default {
   void AddAdvection_SecondOrderUpwind_(double t_old,
           double t_new,
           const Epetra_MultiVector& tcc,
+          Epetra_MultiVector& conserve_qty,
           Epetra_MultiVector& f);
   void AddAdvection_SecondOrderUpwind_(double t_old,
           double t_new,
           const Epetra_Vector& tcc,
+          Epetra_Vector& conserve_qty,          
           Epetra_Vector& f,
           int component);
 

--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -282,6 +282,7 @@ class Transport_ATS : public PK_Physical_Default {
   void AddAdvection_FirstOrderUpwind_(double t_old,
           double t_new,
           const Epetra_MultiVector& tcc,
+          Epetra_MultiVector& conserve_qty,
           Epetra_MultiVector& f);
   void AddAdvection_SecondOrderUpwind_(double t_old,
           double t_new,
@@ -330,6 +331,7 @@ class Transport_ATS : public PK_Physical_Default {
   Key solid_residue_mass_key_; // residue -- mass that was left behind by water
                                // sinks that do not carry aqueous species, e.g. freezing or evaporation
   Key conserve_qty_key_;
+  Key mass_flux_key_;
   Key dispersion_tensor_key_;
 
   // component information

--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -325,7 +325,7 @@ class Transport_ATS : public PK_Physical_Default {
  protected:
 
   // dependencies
-  Key flux_key_; // advecting water flux [mol / s] on faces
+  Key water_flux_key_; // advecting water flux [mol / s] on faces
   Key lwc_key_; // liquid water content [mol]
   Key cv_key_;
 

--- a/src/pks/transport/transport_ats.hh
+++ b/src/pks/transport/transport_ats.hh
@@ -333,7 +333,8 @@ class Transport_ATS : public PK_Physical_Default {
   Key solid_residue_mass_key_; // residue -- mass that was left behind by water
                                // sinks that do not carry aqueous species, e.g. freezing or evaporation
   Key conserve_qty_key_;
-  Key mass_flux_key_;
+  Key mass_flux_advection_key_;
+  Key mass_flux_diffusion_key_;
   Key dispersion_tensor_key_;
 
   // component information

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -589,7 +589,7 @@ Transport_ATS::SetupPhysicalEvaluators_()
   requireEvaluatorAtNext(mass_flux_key_, tag_next_, *S_)
     .SetMesh(mesh_)
     ->SetGhosted(true)
-    ->SetComponent("face", AmanziMesh::Entity_kind::FACE, 1);  
+    ->SetComponent("face", AmanziMesh::Entity_kind::FACE, num_aqueous_);  
 }
 
 

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -1046,7 +1046,7 @@ Transport_ATS::AdvanceAdvectionSources_RK1_(double t_old,
     AddAdvection_FirstOrderUpwind_(t_old, t_new, tcc_old, conserve_qty, mass_flux);
   } else if (spatial_order == 2) {
     // conserve_qty = conserve_qty + div qC
-    AddAdvection_SecondOrderUpwind_(t_old, t_new, tcc_old, conserve_qty);
+    AddAdvection_SecondOrderUpwind_(t_old, t_new, tcc_old, conserve_qty, mass_flux);
   }
   db_->WriteCellVector("qnty (adv)", conserve_qty,
                        S_->GetRecordSet(conserve_qty_key_).subfieldnames());
@@ -1120,7 +1120,7 @@ Transport_ATS::AdvanceAdvectionSources_RK2_(double t_old,
   if (spatial_order == 1) {
     AddAdvection_FirstOrderUpwind_(t_old, t_new, tcc_old, conserve_qty, mass_flux);
   } else if (spatial_order == 2) {
-    AddAdvection_SecondOrderUpwind_(t_old, t_new, tcc_old, conserve_qty);
+    AddAdvection_SecondOrderUpwind_(t_old, t_new, tcc_old, conserve_qty, mass_flux);
   }
   db_->WriteCellVector("qnty (pred adv)", conserve_qty,
                        S_->GetRecordSet(conserve_qty_key_).subfieldnames());
@@ -1162,7 +1162,7 @@ Transport_ATS::AdvanceAdvectionSources_RK2_(double t_old,
     if (spatial_order == 1) {
       AddAdvection_FirstOrderUpwind_(t_old + dt/2., t_new, tcc_new, conserve_qty, mass_flux);
     } else if (spatial_order == 2) {
-      AddAdvection_SecondOrderUpwind_(t_old + dt/2., t_new, tcc_new, conserve_qty);
+      AddAdvection_SecondOrderUpwind_(t_old + dt/2., t_new, tcc_new, conserve_qty, mass_flux);
     }
     db_->WriteCellVector("qnty (corr adv)", conserve_qty,
                          S_->GetRecordSet(conserve_qty_key_).subfieldnames());

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -898,11 +898,10 @@ Transport_ATS ::AdvanceDispersionDiffusion_(double t_old, double t_new)
   if (!has_diffusion_ && !has_dispersion_) return;
   double dt = t_new - t_old;
 
-  // Get tcc_cvs as composite vectors (CVS). This includes both cell and face components.
-  // The face component will used to compute the diffusive mass fluxes in UpdateFlux().
   // The tcc_new is the new tcc viewed as a cell component from the CVS
-  Teuchos::RCP<CompositeVector> tcc_cvs = S_->GetPtrW<CompositeVector>(key_, tag_next_, passwd_);
-  Epetra_MultiVector& tcc_new = *tcc_cvs->ViewComponent("cell", false);
+  // The face component will used to compute the diffusive mass fluxes in UpdateFlux()
+  Epetra_MultiVector& tcc_new = *S_->GetPtrW<CompositeVector>(key_, tag_next_, passwd_)
+    ->ViewComponent("cell", false);
 
   // needed for diffusion coefficent and for accumulation term
   const Epetra_MultiVector& lwc = *S_->Get<CompositeVector>(lwc_key_, tag_next_)
@@ -980,7 +979,7 @@ Transport_ATS ::AdvanceDispersionDiffusion_(double t_old, double t_new)
 
     // get diffusive mass fluxes
     Teuchos::RCP<CompositeVector> cq_flux = S_->GetPtrW<CompositeVector>(mass_flux_diffusion_key_, tag_next_, name_);    
-    diff_op_->UpdateFlux(tcc_cvs.ptr(), cq_flux.ptr());
+    diff_op_->UpdateFlux(diff_sol_.ptr(), cq_flux.ptr());
 
     // -- apply the inverse
     CompositeVector& rhs = *diff_global_op_->rhs();

--- a/src/pks/transport/transport_ats_pk.cc
+++ b/src/pks/transport/transport_ats_pk.cc
@@ -118,7 +118,7 @@ Transport_ATS::parseParameterList()
   mass_flux_advection_key_ = Keys::readKey(*plist_, domain_, "mass flux advection", "mass_flux_advection");
   requireEvaluatorAtNext(mass_flux_advection_key_, tag_next_, *S_, name_);
 
-  mass_flux_diffusion_key_ = Keys::readKey(*plist_, domain_, "mass flux diffusion", "mass_flux_difusion");
+  mass_flux_diffusion_key_ = Keys::readKey(*plist_, domain_, "mass flux diffusion", "mass_flux_diffusion");
   requireEvaluatorAtNext(mass_flux_diffusion_key_, tag_next_, *S_, name_);
 
   // -- liquid water content - need at new time, copy at current time

--- a/src/pks/transport/transport_ats_ti.cc
+++ b/src/pks/transport/transport_ats_ti.cc
@@ -29,18 +29,18 @@ namespace Transport {
 //
 // This uses a first-order donor upwind scheme.
 //
-// DEV NOTE: this requires that tcc is ghosted and scattered, and that cq_flux is
+// DEV NOTE: this requires that tcc is ghosted and scattered, and that c_qty is
 // owned.
 void
 Transport_ATS::AddAdvection_FirstOrderUpwind_(
   double t_old, double t_new,  // old and new time
-  const Epetra_MultiVector& tcc,  // concentration in a cell [mols C / mols H2O]
+  const Epetra_MultiVector& tcc,  // concentration in a cell at old time [mols C / mols H2O]
   Epetra_MultiVector& c_qty,  // component quantity in a cell [mols C]
   Epetra_MultiVector& cq_flux)  // component flux across a face [mols C / s]
 {
   double dt = t_new - t_old;  // time step [s]
 
-  // number of faces in the (local) domain
+  // total number of faces in the domain
   int nfaces_all =
     mesh_->getNumEntities(AmanziMesh::Entity_kind::FACE, AmanziMesh::Parallel_kind::ALL);
   
@@ -116,14 +116,13 @@ Transport_ATS::AddAdvection_FirstOrderUpwind_(
 
     for (auto it = bcs_[m]->begin(); it != bcs_[m]->end(); ++it) {
       int f = it->first;  // get face id
-
       std::vector<double>& values = it->second;
       int c2 = (*downwind_cell_)[f];  // downwind cell id
       int c1 = (*upwind_cell_)[f];  // upwind cell id
 
       double u = std::abs(flux[0][f]);
+      // if downwind cell c2 is inside local domain, update solute fluxes for c2
       if (c2 >= 0 && c2 < c_qty.MyLength()) {
-        // if downwind cell c2 is inside local domain, update solute fluxes for c2
         for (int i = 0; i < ncomp; i++) {
           int k = tcc_index[i];
           if (k < num_aqueous_) {
@@ -138,13 +137,14 @@ Transport_ATS::AddAdvection_FirstOrderUpwind_(
 
 
 void
-Transport_ATS::AddAdvection_SecondOrderUpwind_(double t_old,
-        double t_new,
-        const Epetra_MultiVector& tcc,
-        Epetra_MultiVector& cq_flux)
+Transport_ATS::AddAdvection_SecondOrderUpwind_(
+  double t_old, double t_new,  // old and new time
+  const Epetra_MultiVector& tcc,  // concentration in a cell at old time [mols C / mols H2O]
+  Epetra_MultiVector& c_qty,  // component quantity in a cell [mols C]
+  Epetra_MultiVector& cq_flux)  // component flux across a face [mols C / s]
 {
   for (int i = 0; i != num_aqueous_; ++i) {
-    AddAdvection_SecondOrderUpwind_(t_old, t_new, *tcc(i), *cq_flux(i), i);
+    AddAdvection_SecondOrderUpwind_(t_old, t_new, *tcc(i), *c_qty(i), *cq_flux(i), i);
   }
 }
 
@@ -152,17 +152,20 @@ Transport_ATS::AddAdvection_SecondOrderUpwind_(double t_old,
 //
 // Given C_old, this computes div Cq using a second order limiter
 //
-// DEV NOTE: requires that tcc is ghosted and scattered, while cq_flux is
+// DEV NOTE: requires that tcc is ghosted and scattered, while c_qty is
 // owned.
 void
-Transport_ATS::AddAdvection_SecondOrderUpwind_(double t_old,
-        double t_new,
-        const Epetra_Vector& tcc,
-        Epetra_Vector& cq_flux,
-        int component)
+Transport_ATS::AddAdvection_SecondOrderUpwind_(
+  double t_old, double t_new,
+  const Epetra_Vector& tcc,
+  Epetra_Vector& c_qty,
+  Epetra_Vector& cq_flux,
+  int component)
 {
-  double dt = t_new - t_old;
+  double dt = t_new - t_old;  // time step [s]
 
+  // number of faces owned by this processor
+  // and total number of faces in the domain
   int nfaces_owned =
     mesh_->getNumEntities(AmanziMesh::Entity_kind::FACE, AmanziMesh::Parallel_kind::OWNED);
   int nfaces_all =
@@ -188,73 +191,75 @@ Transport_ATS::AddAdvection_SecondOrderUpwind_(double t_old,
     int c1 = (*upwind_cell_)[f];
     int c2 = (*downwind_cell_)[f];
 
-    double u1, u2, umin, umax;
+    double tcc1, tcc2, tccmin, tccmax;
     if (c1 >= 0 && c2 >= 0) {
-      u1 = tcc[c1];
-      u2 = tcc[c2];
-      umin = std::min(u1, u2);
-      umax = std::max(u1, u2);
+      tcc1 = tcc[c1];
+      tcc2 = tcc[c2];
+      tccmin = std::min(tcc1, tcc2);
+      tccmax = std::max(tcc1, tcc2);
     } else if (c1 >= 0) {
-      u1 = u2 = umin = umax = tcc[c1];
+      tcc1 = tcc2 = tccmin = tccmax = tcc[c1];
     } else if (c2 >= 0) {
-      u1 = u2 = umin = umax = tcc[c2];
+      tcc1 = tcc2 = tccmin = tccmax = tcc[c2];
     }
 
     double u = std::abs((*flux)[0][f]);
     const AmanziGeometry::Point& xf = mesh_->getFaceCentroid(f);
 
-    double upwind_tcc, tcc_flux;
-    if (c1 >= 0 && c1 < cq_flux.MyLength() && c2 >= 0 && c2 < cq_flux.MyLength() ) {
+    double upwind_tcc, delta_c_mass;
+    if (c1 >= 0 && c1 < c_qty.MyLength() && c2 >= 0 && c2 < c_qty.MyLength() ) {
       upwind_tcc = limiter_->getValue(c1, xf);
-      upwind_tcc = std::max(upwind_tcc, umin);
-      upwind_tcc = std::min(upwind_tcc, umax);
+      upwind_tcc = std::max(upwind_tcc, tccmin);
+      upwind_tcc = std::min(upwind_tcc, tccmax);
 
-      tcc_flux = dt * u * upwind_tcc;
-      cq_flux[c1] -= tcc_flux;
-      cq_flux[c2] += tcc_flux;
+      delta_c_mass = dt * u * upwind_tcc;
+      c_qty[c1] -= delta_c_mass;  // [mols C]
+      c_qty[c2] += delta_c_mass;  // [mols C]
 
-    } else if (c1 >= 0 && c1 < cq_flux.MyLength() && (c2 >= cq_flux.MyLength() || c2 < 0)) {
+    } else if (c1 >= 0 && c1 < c_qty.MyLength() && (c2 >= c_qty.MyLength() || c2 < 0)) {
       upwind_tcc = limiter_->getValue(c1, xf);
-      upwind_tcc = std::max(upwind_tcc, umin);
-      upwind_tcc = std::min(upwind_tcc, umax);
+      upwind_tcc = std::max(upwind_tcc, tccmin);
+      upwind_tcc = std::min(upwind_tcc, tccmax);
 
-      tcc_flux = dt * u * upwind_tcc;
-      cq_flux[c1] -= tcc_flux;
+      delta_c_mass = dt * u * upwind_tcc;
+      c_qty[c1] -= delta_c_mass;  // [mols C]
 
-    } else if (c1 >= 0 && c1 < cq_flux.MyLength() && (c2 < 0)) {
+    } else if (c1 >= 0 && c1 < c_qty.MyLength() && (c2 < 0)) {
       upwind_tcc = tcc[c1];
-      upwind_tcc = std::max(upwind_tcc, umin);
-      upwind_tcc = std::min(upwind_tcc, umax);
+      upwind_tcc = std::max(upwind_tcc, tccmin);
+      upwind_tcc = std::min(upwind_tcc, tccmax);
 
-      tcc_flux = dt * u * upwind_tcc;
-      cq_flux[c1] -= tcc_flux;
+      delta_c_mass = dt * u * upwind_tcc;
+      c_qty[c1] -= delta_c_mass;  // [mols C]
 
-    } else if (c1 >= cq_flux.MyLength() && c2 >= 0 && c2 < cq_flux.MyLength() ) {
+    } else if (c1 >= c_qty.MyLength() && c2 >= 0 && c2 < c_qty.MyLength() ) {
       upwind_tcc = limiter_->getValue(c1, xf);
-      upwind_tcc = std::max(upwind_tcc, umin);
-      upwind_tcc = std::min(upwind_tcc, umax);
+      upwind_tcc = std::max(upwind_tcc, tccmin);
+      upwind_tcc = std::min(upwind_tcc, tccmax);
 
-      tcc_flux = dt * u * upwind_tcc;
-      cq_flux[c2] += tcc_flux;
+      delta_c_mass = dt * u * upwind_tcc;  // [mols C]
+      c_qty[c2] += delta_c_mass;
     }
+    cq_flux[f] = u * upwind_tcc;  // [mols C / s]
   }
 
   // boundary conditions for advection
   for (int m = 0; m < bcs_.size(); m++) {
     std::vector<int>& tcc_index = bcs_[m]->tcc_index();
-    int ncomp = tcc_index.size();
+    int ncomp = tcc_index.size();  // number of components
 
     for (int i = 0; i < ncomp; i++) {
       if (component == tcc_index[i]) {
         for (auto it = bcs_[m]->begin(); it != bcs_[m]->end(); ++it) {
-          int f = it->first;
-          std::vector<double>& values = it->second;
-          int c2 = (*downwind_cell_)[f];
+          int f = it->first;  // get face id
+          std::vector<double>& values = it->second;  // concentration values [mols C / mols H2O]
+          int c2 = (*downwind_cell_)[f];  // get downwind cell id
 
-          if (c2 >= 0 && f < nfaces_owned) {
-            double u = std::abs((*flux)[0][f]);
-            double tcc_flux = dt * u * values[i];
-            cq_flux[c2] += tcc_flux;
+          // if downwind cell c2 is inside local domain and face id is owned by this processor
+          if (c2 >= 0 && f < nfaces_owned) {            
+            double u = std::abs((*flux)[0][f]);  // water flux [mols H2O / s]
+            double delta_c_mass = dt * u * values[i];  // [mols C]
+            c_qty[c2] += delta_c_mass;  // [mols C]
           }
         }
       }

--- a/src/pks/transport/transport_ats_ti.cc
+++ b/src/pks/transport/transport_ats_ti.cc
@@ -38,14 +38,14 @@ Transport_ATS::AddAdvection_FirstOrderUpwind_(
   Epetra_MultiVector& c_qty,  // component quantity in a cell [mols C]
   Epetra_MultiVector& cq_flux)  // component flux across a face [mols C / s]
 {
-  double dt = t_new - t_old;  // time step [s]
+  double dt = t_new - t_old;  // timestep [s]
 
   // total number of faces in the domain
   int nfaces_all =
     mesh_->getNumEntities(AmanziMesh::Entity_kind::FACE, AmanziMesh::Parallel_kind::ALL);
   
-    // get water flux (flux_key_) for each face at next time step (tag_next_)
-  const Epetra_MultiVector& flux = *S_->Get<CompositeVector>(flux_key_, tag_next_)
+    // get water flux (water_flux_key_) for each face at next timestep (tag_next_)
+  const Epetra_MultiVector& flux = *S_->Get<CompositeVector>(water_flux_key_, tag_next_)
     .ViewComponent("face", true);
 
   // advance all components at once
@@ -162,7 +162,7 @@ Transport_ATS::AddAdvection_SecondOrderUpwind_(
   Epetra_Vector& cq_flux,
   int component)
 {
-  double dt = t_new - t_old;  // time step [s]
+  double dt = t_new - t_old;  // timestep [s]
 
   // number of faces owned by this processor
   // and total number of faces in the domain
@@ -180,7 +180,7 @@ Transport_ATS::AddAdvection_SecondOrderUpwind_(
   auto& bc_model = adv_bcs_->bc_model();
   auto& bc_value = adv_bcs_->bc_value();
 
-  auto flux = S_->Get<CompositeVector>(flux_key_, tag_next_).ViewComponent("face", true);
+  auto flux = S_->Get<CompositeVector>(water_flux_key_, tag_next_).ViewComponent("face", true);
   limiter_->SetFlux(flux);
   limiter_->ApplyLimiter(tcc_rcp, 0, lifting_, bc_model, bc_value);
 


### PR DESCRIPTION
This pull request adds functionality to output solute mass flux observations across faces and domain boundary, incorporating both advective and diffusive components.

This addresses the feature request raised in issue #275.

**Checklist**
- Added support for advective flux observation output -- ✅ **Done** 
- Added support for diffusive flux observation output --  ✅ **Done** 
- Included handling for both internal faces and domain boundaries -- ✅ **Done**  
- Update relevant transport regression tests -- 🔄 **In Progress** 
- Updated documentation -- 📝 **Planned**