### PR TITLE
Fix C-Q evaluator bug: use current cell concentration for outgoing flux

### DIFF
--- a/src/pks/transport/constitutive_relations/sources/qc_relation_field_evaluator.cc
+++ b/src/pks/transport/constitutive_relations/sources/qc_relation_field_evaluator.cc
@@ -26,6 +26,7 @@ QCRelationFieldEvaluator::QCRelationFieldEvaluator(Teuchos::ParameterList& plist
   cv_key_ = Keys::readKey(plist, domain_, "cell volume", "cell_volume");
   dependencies_.insert(KeyTag{ cv_key_, tag });
   molar_density_key_ = Keys::readKey(plist, domain_, "molar density liquid", "molar_density_liquid");
+  tcc_key_ = Keys::readKey(plist, domain_, "concentration", "total_component_concentration");
   dependencies_.insert(KeyTag{ molar_density_key_, tag });
   field_src_key_ = Keys::readKey(plist, domain_, "field source", "water_source_field");
   dependencies_.insert(KeyTag{ field_src_key_, tag });
@@ -49,30 +50,39 @@ QCRelationFieldEvaluator::Evaluate_(const State& S, const std::vector<CompositeV
   const auto& cv = *S.Get<CompositeVector>(cv_key_, tag).ViewComponent("cell", false);
   const auto& molar_den =
     *S.Get<CompositeVector>(molar_density_key_, tag).ViewComponent("cell", false);
+  const auto& tcc = *S.Get<CompositeVector>(tcc_key_, tag).ViewComponent("cell", false);    
   const auto& water_from_field =
     *S.Get<CompositeVector>(field_src_key_, tag).ViewComponent("cell", false);
   auto& surf_src = *result[0]->ViewComponent("cell"); // not being reference
   const AmanziMesh::Mesh& mesh = *result[0]->Mesh();
-  double field_flow, source_mass;
+  double field_flow, source_mass, tcc_current;
   
   // Loop through each cell
   AmanziMesh::Entity_ID ncells = cv.MyLength();
   for (AmanziMesh::Entity_ID c = 0; c != ncells; ++c) {
     
     if (extensive_) {
-      // convert extensive quantity in mol/m2/s to m3/s
+      // convert extensive quantity in mol/s to m3/s
       field_flow = water_from_field[0][c] / molar_den[0][c];
     } else {
-      // convert intensive quantity from mol/s to m3/s
+      // convert intensive quantity from mol/m2/s to m3/s
       field_flow = water_from_field[0][c] * cv[0][c] / molar_den[0][c];
     }
+    // current concentration
+    tcc_current = tcc[0][c];
 
-    // transport source (concentration g/m3) as a function of discharge from a field (e.g. tile, groundwater)
-    source_mass = (*QC_curve_)(std::vector<double>{field_flow});
-
-    // return solute mass rate by multiplying with discharge (molC/s)
-    // Here we assume the molar mass is 1. TODO: add molar mass to the function.
-    surf_src[0][c] = source_mass * field_flow * molar_den[0][c] / cv[0][c];
+    // transport source (concentration g/m3) as a function of discharge from a field
+    source_mass = (*QC_curve_)(std::vector<double>{std::abs(field_flow)});
+    
+    // temporarily assume molar mass is 1.0
+    // TODO: read molar mass from the xml file
+    if (field_flow > 0) {
+      // positive flux means source, concentration is from source_transport
+      surf_src[0][c] = source_mass * field_flow * 1.0;
+    } else {
+      // negative flux means sink, concentration is the same as the current concentration
+      surf_src[0][c] = tcc_current * field_flow * 1.0;
+    }    
   }
 }
 

--- a/src/pks/transport/constitutive_relations/sources/qc_relation_field_evaluator.hh
+++ b/src/pks/transport/constitutive_relations/sources/qc_relation_field_evaluator.hh
@@ -80,6 +80,7 @@ class QCRelationFieldEvaluator : public EvaluatorSecondaryMonotypeCV {
   Key domain_;
   Key cv_key_;
   Key molar_density_key_;
+  Key tcc_key_;
   Key field_src_key_;
   bool extensive_;
   Teuchos::RCP<Function> QC_curve_;

--- a/src/pks/transport/constitutive_relations/sources/qc_relation_overland_evaluator.cc
+++ b/src/pks/transport/constitutive_relations/sources/qc_relation_overland_evaluator.cc
@@ -46,6 +46,7 @@ QCRelationOverlandEvaluator::Evaluate_(const State& S, const std::vector<Composi
   const auto& cv = *S.Get<CompositeVector>(cv_key_, tag).ViewComponent("cell", false);
   const auto& molar_den =
     *S.Get<CompositeVector>(molar_density_key_, tag).ViewComponent("cell", false);
+  const auto& tcc = *S.Get<CompositeVector>(tcc_key_, tag).ViewComponent("cell", false);    
   const auto& water_from_field =
     *S.Get<CompositeVector>(field_src_key_, tag).ViewComponent("face", false);
   auto& surf_src = *result[0]->ViewComponent("cell"); // not being reference
@@ -58,26 +59,38 @@ QCRelationOverlandEvaluator::Evaluate_(const State& S, const std::vector<Composi
   // mesh.getFaceCells(f).size() == 1: Face on the river bank connecting overland and river cells (use)
   // mesh.getFaceCells(f).size() == 2: Internal face connecting two river cells (ignore)
   for (AmanziMesh::Entity_ID c = 0; c != ncells; ++c) {
+    AmanziGeometry::Point centroid = mesh.getCellCentroid(c);
     double total_external_flux = 0;
     const auto& [faces, dirs] = mesh.getCellFacesAndDirections(c);
     int nfaces = faces.size();
     
     for (int i = 0; i < nfaces; i++) {
       int f = faces[i];     // get each face of the cell
-      double dir = dirs[i]; // 1: water goes out of the cell; -1: water goes into the cell
-
-      if (mesh.getFaceCells(f).size() == 1) {
-        // external faces which contributes sinks/sources
+      double dir = dirs[i]; // 1: water goes out of the cell; -1: water goes into the cell      
+      if ((mesh.getFaceCells(f).size() == 1) && (dir == -1)) {
+        // External faces are adjacent to only one cell (size() == 1).
+        // Flux through these faces represents sources or sinks to/from the overland flow.                
         total_external_flux += water_from_field[0][f] * (-dir);
-      }
+      }  
     }
-    
+    // current concentration
+    double tcc_current = tcc[0][c];
+
     // convert from mol/s to m3/s. We do NOT multiply with cv here
     double total_flux_meter = total_external_flux / molar_den[0][c];
 
-    // transport source (mass) as a function of discharge (e.g. overland)
-    double source_transport = (*QC_curve_)(std::vector<double>{ total_flux_meter });
-    surf_src[0][c] = source_transport * total_flux_meter * molar_den[0][c] / cv[0][c];
+    // transport source (mass/volume e.g., mg/m3) as a function of discharge (e.g. overland)
+    double source_transport = (*QC_curve_)(std::vector<double>{ std::abs(total_flux_meter) });
+    
+    // temporarily assume molar mass is 1.0
+    // TODO: read molar mass from the xml file
+    if (total_flux_meter > 0) {
+      // positive flux means source, concentration is from source_transport
+      surf_src[0][c] = source_transport * total_flux_meter * 1.0;
+    } else {
+      // negative flux means sink, concentration is the same as the current concentration
+      surf_src[0][c] = tcc_current * total_flux_meter * 1.0;
+    }
   }
 }
 

--- a/src/pks/transport/constitutive_relations/sources/qc_relation_overland_evaluator.hh
+++ b/src/pks/transport/constitutive_relations/sources/qc_relation_overland_evaluator.hh
@@ -77,6 +77,7 @@ class QCRelationOverlandEvaluator : public EvaluatorSecondaryMonotypeCV {
   Key domain_;
   Key cv_key_;
   Key molar_density_key_;
+  Key tcc_key_;
   Key field_src_key_;
   Teuchos::RCP<Function> QC_curve_;
 


### PR DESCRIPTION
This PR fix the bug for C-Q evaluator that flux leaving the domain uses the current cell concentration, not the concentration from the C-Q relationship. 
Closes #276.