### PR TITLE
Add Kokkos::initialize/finalize for ELM ATS API

### DIFF
--- a/src/executables/elm_ats_api/elm_ats_api.cc
+++ b/src/executables/elm_ats_api/elm_ats_api.cc
@@ -27,7 +27,8 @@ extern "C"
   void ats_delete(ELM_ATSDriver_ptr ats)
   {
     auto ats_ptr = reinterpret_cast<ATS::ELM_ATSDriver*>(ats);
-    ats_ptr->finalize();
+    Kokkos::finalize();
+    //ats_ptr->finalize();
     delete ats_ptr;
   }
 

--- a/src/executables/elm_ats_api/elm_ats_api.cc
+++ b/src/executables/elm_ats_api/elm_ats_api.cc
@@ -16,7 +16,7 @@
 
 namespace {
   // did ATS initialize kokkos?
-  ats_kokkos_init = false;
+  bool ats_kokkos_init = false;
 }
 
 extern "C"
@@ -30,7 +30,7 @@ extern "C"
     if (!Kokkos::is_initialized()) {
       Kokkos::initialize();
       ats_kokkos_init = true;
-      std::cout << "Initializing Kokkos in ELM-ATS driver wrapper"
+      std::cout << "Initializing Kokkos in ELM-ATS driver wrapper";
     }
     return reinterpret_cast<ELM_ATSDriver_ptr>(ATS::createELM_ATSDriver(f_comm, input_filename));
   }

--- a/src/executables/elm_ats_api/elm_ats_api.cc
+++ b/src/executables/elm_ats_api/elm_ats_api.cc
@@ -30,7 +30,6 @@ extern "C"
     if (!Kokkos::is_initialized()) {
       Kokkos::initialize();
       ats_kokkos_init = true;
-      std::cout << "Initializing Kokkos in ELM-ATS driver wrapper";
     }
     return reinterpret_cast<ELM_ATSDriver_ptr>(ATS::createELM_ATSDriver(f_comm, input_filename));
   }

--- a/src/executables/elm_ats_api/elm_ats_api.cc
+++ b/src/executables/elm_ats_api/elm_ats_api.cc
@@ -30,6 +30,7 @@ extern "C"
     if (!Kokkos::is_initialized()) {
       Kokkos::initialize();
       ats_kokkos_init = true;
+      std::cout << "Initializing Kokkos in ELM-ATS driver wrapper"
     }
     return reinterpret_cast<ELM_ATSDriver_ptr>(ATS::createELM_ATSDriver(f_comm, input_filename));
   }

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -29,7 +29,6 @@ namespace ATS {
 ELM_ATSDriver*
 createELM_ATSDriver(MPI_Fint* f_comm, const char* infile, int npfts)
 {
-  if (!Kokkos::is_initialized()) Kokkos::initialize(); // or ScopeGuard?
   // -- create communicator & get process rank
   //auto comm = getDefaultComm();
   auto c_comm = MPI_Comm_f2c(*f_comm);

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -29,6 +29,7 @@ namespace ATS {
 ELM_ATSDriver*
 createELM_ATSDriver(MPI_Fint* f_comm, const char* infile, int npfts)
 {
+  if (!Kokkos::is_initialized()) Kokkos::initialize(); // or ScopeGuard?
   // -- create communicator & get process rank
   //auto comm = getDefaultComm();
   auto c_comm = MPI_Comm_f2c(*f_comm);


### PR DESCRIPTION
Currently `Kokkos::initialize()` and `Kokkos::finalize()` are only called in main. If calling ATS via the ELM-ATS API, these are never invoked leading to a crash when meshing invokes `View()`. 

Small patch fixes this issue and attempts to guard against double initialization if there is ever a version of ELM that initializes Kokkos first.