### PR TITLE
Add dependabot to keep actions versions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    groups:
+      action-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
Mirroring amanzi/amanzi#953. Our CI jobs have a lot of actions, with many of them being marked obsolete now due to the Node20 deprecation.

This PR adds a weekly job that checks for updates in these actions weekly, and opens a PR with only a few lines of changes (possibly as few as one) that automatically updates the action if there is a newer version, ensuring that we won't have to deal with these deprecation warnings in the future. If new PR passes CI, should be able to be merged quickly.

This will create at most a single PR per week, grouping all of the relevant actions that need to be updated into a single PR.