### PR TITLE
Updates to ELM_ATS wrappers

### DIFF
--- a/src/constitutive_relations/CMakeLists.txt
+++ b/src/constitutive_relations/CMakeLists.txt
@@ -86,6 +86,11 @@ register_evaluator_with_factory(
   )
 
 register_evaluator_with_factory(
+  HEADERFILE generic_evaluators/EvaluatorTimeAccumulated_reg.hh
+  LISTNAME ATS_RELATIONS_REG
+  )
+
+register_evaluator_with_factory(
   HEADERFILE generic_evaluators/ExtractionEvaluator_reg.hh
   LISTNAME ATS_RELATIONS_REG
   )

--- a/src/constitutive_relations/generic_evaluators/CMakeLists.txt
+++ b/src/constitutive_relations/generic_evaluators/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ats_generic_evals_src_files
     TimeMaxEvaluator.cc
     ExtractionEvaluator.cc
     InitialTimeEvaluator.cc
+    EvaluatorTimeAccumulated.cc
    )
 
 file(GLOB ats_generic_evals_inc_files "*.hh")

--- a/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated.cc
+++ b/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated.cc
@@ -1,0 +1,164 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (coonet@ornl.gov)
+*/
+
+#include "EvaluatorTimeAccumulated.hh"
+
+namespace Amanzi {
+namespace Relations {
+
+EvaluatorTimeAccumulated::EvaluatorTimeAccumulated(Teuchos::ParameterList& plist)
+  : EvaluatorSecondary(plist)
+{
+  // my_keys_[0] was populated by EvaluatorSecondary from the plist name/tag.
+  const auto& my_key = my_keys_.front().first;
+  const auto& my_tag = my_keys_.front().second;
+
+  accumulation_type_ = plist_.get<std::string>("accumulation type", "integral");
+  if (accumulation_type_ != "integral" && accumulation_type_ != "min" &&
+      accumulation_type_ != "max") {
+    Errors::Message msg;
+    msg << "EvaluatorTimeAccumulated for \"" << my_key << "\": invalid \"accumulation type\" \""
+        << accumulation_type_ << "\", must be one of: integral, min, max";
+    Exceptions::amanzi_throw(msg);
+  }
+
+  auto domain = Keys::getDomain(my_key);
+  accumulated_key_ = Keys::readKey(plist_, domain, "accumulated", Keys::getVarName(my_key));
+
+  if (!plist_.isParameter("accumulated tag")) {
+    Errors::Message msg;
+    msg << "EvaluatorTimeAccumulated for \"" << my_key
+        << "\": missing required parameter \"accumulated tag\"";
+    Exceptions::amanzi_throw(msg);
+  }
+  accumulated_tag_ = Tag(plist_.get<std::string>("accumulated tag"));
+
+  // my_keys_[1]: the accumulated-dt scalar, same tag as the CV result
+  Key acc_dt_key = my_key + "_accumulated_dt";
+  my_keys_.emplace_back(KeyTag{ acc_dt_key, my_tag });
+
+  // accumulated_key@accumulated_tag changes each inner step — triggers Update_()
+  dependencies_.insert(KeyTag(accumulated_key_, accumulated_tag_));
+
+  // no evaluator for dt, so can't add it to dependencies
+  // dt@accumulated_tag provides the inner timestep size for weighting
+  //dependencies_.insert(KeyTag("dt", accumulated_tag_));
+}
+
+
+Teuchos::RCP<Evaluator>
+EvaluatorTimeAccumulated::Clone() const
+{
+  return Teuchos::rcp(new EvaluatorTimeAccumulated(*this));
+}
+
+
+void
+EvaluatorTimeAccumulated::EnsureCompatibility(State& S)
+{
+  // my_keys_[0]: CV result — claim ownership; structure flows from client requirements
+  const auto& [cv_key, cv_tag] = my_keys_[0];
+  auto& my_fac = S.Require<CompositeVector, CompositeVectorSpace>(cv_key, cv_tag, cv_key);
+
+  // my_keys_[1]: accumulated-dt scalar — claim ownership
+  const auto& [dt_key, dt_tag] = my_keys_[1];
+  S.Require<double>(dt_key, dt_tag, dt_key);
+
+  // wire dependency evaluators into the graph
+  if (my_fac.Mesh() != Teuchos::null) {
+    for (const auto& dep : dependencies_)
+      // dependency fac includes my fac
+      S.Require<CompositeVector, CompositeVectorSpace>(dep.first, dep.second)
+        .Update(my_fac);
+  }
+
+  EvaluatorSecondary::EnsureCompatibility_Flags_(S);
+}
+
+
+void
+EvaluatorTimeAccumulated::Update_(State& S)
+{
+  const auto& [cv_key, cv_tag] = my_keys_[0];
+  const auto& [dt_key, dt_tag] = my_keys_[1];
+
+  double dt_inner = S.Get<double>("dt", accumulated_tag_);
+  const auto& source = S.Get<CompositeVector>(accumulated_key_, accumulated_tag_);
+  double acc_dt = S.Get<double>(dt_key, dt_tag);
+  if (dt_inner > 0) {
+    // cv is read and overwritten in place — valid because we own it
+    auto& cv = S.GetW<CompositeVector>(cv_key, cv_tag, cv_key);
+
+    if (accumulation_type_ == "integral") {
+      double total_dt = acc_dt + dt_inner;
+      for (const auto& comp : cv) {
+        auto& res = *cv.ViewComponent(comp, false);
+        const auto& src = *source.ViewComponent(comp, false);
+        for (int j = 0; j != res.NumVectors(); ++j)
+          for (int i = 0; i != res.MyLength(); ++i)
+            res[j][i] = (res[j][i] * acc_dt + src[j][i] * dt_inner) / total_dt;
+      }
+    } else if (accumulation_type_ == "max") {
+      for (const auto& comp : cv) {
+        auto& res = *cv.ViewComponent(comp, false);
+        const auto& src = *source.ViewComponent(comp, false);
+        for (int j = 0; j != res.NumVectors(); ++j)
+          for (int i = 0; i != res.MyLength(); ++i)
+            res[j][i] = std::max(res[j][i], src[j][i]);
+      }
+    } else { // min
+      for (const auto& comp : cv) {
+        auto& res = *cv.ViewComponent(comp, false);
+        const auto& src = *source.ViewComponent(comp, false);
+        for (int j = 0; j != res.NumVectors(); ++j)
+          for (int i = 0; i != res.MyLength(); ++i)
+            res[j][i] = std::min(res[j][i], src[j][i]);
+      }
+    }
+
+    S.GetW<double>(dt_key, dt_tag, dt_key) = acc_dt + dt_inner;
+
+    if (vo_.os_OK(Teuchos::VERB_EXTREME)) {
+      Teuchos::OSTab tab = vo_.getOSTab();
+      *vo_.os() << "Updated time accumulation time from " << acc_dt << " to " << acc_dt + dt_inner << std::endl;
+      cv.Print(std::cout);
+    }
+  }
+}
+
+
+void
+EvaluatorTimeAccumulated::Reset(State& S)
+{
+  const auto& [cv_key, cv_tag] = my_keys_[0];
+  const auto& [dt_key, dt_tag] = my_keys_[1];
+
+  if (vo_.os_OK(Teuchos::VERB_EXTREME)) {
+    Teuchos::OSTab tab = vo_.getOSTab();
+    *vo_.os() << "Resetting time accumulation" << std::endl;
+  }
+
+  auto& cv = S.GetW<CompositeVector>(cv_key, cv_tag, cv_key);
+  if (accumulation_type_ == "max") {
+    cv.PutScalar(-1.e16);
+  } else if (accumulation_type_ == "min") {
+    cv.PutScalar(1.e16);
+  } else {
+    cv.PutScalar(0.);
+  }
+
+  S.GetW<double>(dt_key, dt_tag, dt_key) = 0.;
+
+  // invalidate lazy cache so the next Update() call always runs Update_()
+  requests_.clear();
+}
+
+
+} // namespace Relations
+} // namespace Amanzi

--- a/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated.cc
+++ b/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated.cc
@@ -78,6 +78,7 @@ EvaluatorTimeAccumulated::EnsureCompatibility(State& S)
         .Update(my_fac);
   }
 
+  EvaluatorSecondary::EnsureCompatibility_DepEnsureCompatibility_(S);
   EvaluatorSecondary::EnsureCompatibility_Flags_(S);
 }
 

--- a/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated.hh
+++ b/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated.hh
@@ -1,0 +1,93 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (coonet@ornl.gov)
+*/
+
+/*!
+
+Accumulates a field pointwise over time, computing either a time-integrated
+average, a running maximum, or a running minimum.
+
+This evaluator is designed for use with subcycled MPCs.  It lives at
+``tag`` (typically ``Tags::NEXT``) and depends on the source field at
+``accumulated_tag`` (the subcycled inner tag, e.g. ``flow_next``).  The
+``TimeAdvancer`` driving the inner subcycle loop is responsible for calling
+``Reset()`` at the start of each outer timestep and ``Update()`` after each
+successful inner step.
+
+For ``integral`` mode the result is the time-weighted mean:
+
+  new_val = (old_val * acc_dt + source * dt) / (acc_dt + dt)
+
+For ``min`` / ``max`` modes the result is the running pointwise
+minimum / maximum; accumulated time is still tracked so that ``Reset()``
+can initialise correctly.
+
+Both the result ``CompositeVector`` and the ``KEY_accumulated_dt`` scalar are
+checkpointed so that the accumulation survives restarts mid outer-step.
+
+`"evaluator type`" = `"time accumulated`"
+
+.. _evaluator-time-accumulated-spec:
+.. admonition:: evaluator-time-accumulated-spec
+
+   * `"accumulation type`" ``[string]`` **"integral"** One of ``integral``,
+     ``min``, or ``max``.
+
+   * `"accumulated key`" ``[string]`` **my_key** Key of the field to
+     accumulate.  Defaults to the same key as this evaluator.
+
+   * `"accumulated tag`" ``[string]`` **required** Tag at which the source
+     field is evaluated (the subcycled inner tag).
+
+*/
+
+#pragma once
+
+#include "Factory.hh"
+#include "EvaluatorSecondary.hh"
+
+namespace Amanzi {
+namespace Relations {
+
+class EvaluatorTimeAccumulated : public EvaluatorSecondary {
+ public:
+  explicit EvaluatorTimeAccumulated(Teuchos::ParameterList& plist);
+  EvaluatorTimeAccumulated(const EvaluatorTimeAccumulated& other) = default;
+  Teuchos::RCP<Evaluator> Clone() const override;
+
+  bool IsDifferentiableWRT(const State& S,
+                           const Key& wrt_key,
+                           const Tag& wrt_tag) const override
+  {
+    return false;
+  }
+
+  void EnsureCompatibility(State& S) override;
+
+  // Zeros the accumulator and clears the lazy-evaluation cache.
+  // Called by TimeAdvancer before each outer timestep's inner loop.
+  void Reset(State& S);
+
+ protected:
+  void Update_(State& S) override;
+  void UpdateDerivative_(State& S, const Key& wrt_key, const Tag& wrt_tag) override {}
+
+ protected:
+  Key accumulated_key_;
+  Tag accumulated_tag_;
+  std::string accumulation_type_;  // "integral", "min", "max"
+
+  // my_keys_[0] = {key, tag}         — the CV result
+  // my_keys_[1] = {acc_dt_key, tag}  — the accumulated-dt scalar
+
+ private:
+  static Utils::RegisteredFactory<Evaluator, EvaluatorTimeAccumulated> reg_;
+};
+
+} // namespace Relations
+} // namespace Amanzi

--- a/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated_reg.hh
+++ b/src/constitutive_relations/generic_evaluators/EvaluatorTimeAccumulated_reg.hh
@@ -1,0 +1,19 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (coonet@ornl.gov)
+*/
+
+#include "EvaluatorTimeAccumulated.hh"
+
+namespace Amanzi {
+namespace Relations {
+
+Utils::RegisteredFactory<Evaluator, EvaluatorTimeAccumulated>
+  EvaluatorTimeAccumulated::reg_("time accumulated");
+
+} // namespace Relations
+} // namespace Amanzi

--- a/src/executables/CMakeLists.txt
+++ b/src/executables/CMakeLists.txt
@@ -65,13 +65,13 @@ include_evaluators_directories(LISTNAME SED_TRANSPORT_REG_INCLUDES)
 
 set(ats_src_files
   ats_mesh_factory.cc
-  coordinator.cc
+  driver.cc
   ats_driver.cc
   )
 
 set(ats_inc_files
   ats_mesh_factory.hh
-  coordinator.hh
+  driver.hh
   ats_driver.hh
   )
 

--- a/src/executables/ats_driver.cc
+++ b/src/executables/ats_driver.cc
@@ -4,7 +4,7 @@
   The terms of use and "as is" disclaimer for this license are
   provided in the top-level COPYRIGHT file.
 
-  Authors:
+  Authors: Ethan Coon
 */
 
 #include <iostream>
@@ -13,33 +13,21 @@
 #include <Epetra_MpiComm.h>
 
 #include "Teuchos_ParameterList.hpp"
-#include "Teuchos_CommandLineProcessor.hpp"
-#include "Teuchos_VerboseObjectParameterListHelpers.hpp"
-#include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 #include "VerboseObject.hh"
 
 #include "AmanziComm.hh"
 #include "AmanziTypes.hh"
 
-#include "InputAnalysis.hh"
-#include "Units.hh"
-#include "CompositeVector.hh"
 #include "TimeStepManager.hh"
-#include "Visualization.hh"
-#include "VisualizationDomainSet.hh"
-#include "IO.hh"
-#include "Checkpoint.hh"
-#include "UnstructuredObservations.hh"
 #include "State.hh"
 #include "PK.hh"
-#include "TreeVector.hh"
-#include "PK_Factory.hh"
+#include "IO.hh"
 
-#include "PK_Helpers.hh"
 #include "exceptions.hh"
 #include "errors.hh"
 
+#include "time_advancer.hh"
 #include "ats_driver.hh"
 
 // won't run if DEBUG_MODE == false
@@ -49,16 +37,32 @@
 
 namespace ATS {
 
-// -----------------------------------------------------------------------------
-// setup and initialize, then run until time >= duration_
-// -----------------------------------------------------------------------------
 void
-ATSDriver::cycle_driver()
+ATSDriver::createTimeAdvancer_()
+{
+  // build a combined plist: done conditions + dt bounds from coordinator_list_,
+  // vis/obs/checkpoint from plist_ top-level sublists
+  auto ta_plist = Teuchos::rcp(new Teuchos::ParameterList(*coordinator_list_));
+  if (plist_->isSublist("checkpoint"))
+    ta_plist->sublist("checkpoint") = plist_->sublist("checkpoint");
+  if (plist_->isSublist("observations"))
+    ta_plist->sublist("observations") = plist_->sublist("observations");
+  if (plist_->isSublist("visualization"))
+    ta_plist->sublist("visualization") = plist_->sublist("visualization");
+  if (plist_->isSublist("visualization failed"))
+    ta_plist->sublist("visualization failed") = plist_->sublist("visualization failed");
+
+  time_advancer_ = Teuchos::rcp(new TimeAdvancer(
+    ta_plist, S_, pk_, tsm_,
+    Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT,
+    vo_, wallclock_timer_));
+}
+
+
+void
+ATSDriver::cycle_driver_()
 {
   Teuchos::OSTab tab = vo_->getOSTab();
-
-  // wallclock duration -- in seconds
-  const double duration(duration_ * 3600);
 
   //
   // setup phase
@@ -74,6 +78,10 @@ ATSDriver::cycle_driver()
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("2a: parseParameterList");
   }
+
+  // TimeAdvancer must be created after parseParameterList (tags/PKs set up)
+  // but before setup() so observations can call Setup(S_) before State::Setup()
+  createTimeAdvancer_();
 
   setup();
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
@@ -92,18 +100,8 @@ ATSDriver::cycle_driver()
   }
   initialize();
 
-  // get the intial timestep
-  double dt = get_dt(false);
-  S_->Assign<double>("dt", Amanzi::Tags::DEFAULT, "dt", dt);
-
-  // Write dependency graph, initial state
   S_->WriteDependencyGraph();
   WriteStateStatistics(*S_, *vo_);
-
-  // checkpoint, observe, and vis at initial time
-  visualize();
-  observe();
-  checkpoint();
 
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
@@ -120,65 +118,22 @@ ATSDriver::cycle_driver()
                << std::flush;
   }
 
-  // iterate process kernels
-  //
-  // Make sure times are set up correctly
   {
     Teuchos::TimeMonitor timer(*timers_.at("4: solve"));
-    AMANZI_ASSERT(std::abs(S_->get_time(Amanzi::Tags::NEXT) - S_->get_time(Amanzi::Tags::CURRENT)) <
-                  1.e-4);
-    AMANZI_ASSERT(std::abs(dt - S_->Get<double>("dt", Amanzi::Tags::DEFAULT)) < 1.e-4);
 
 #if !DEBUG_MODE
     try {
 #endif
-      while (((t1_ < 0) || (S_->get_time() < t1_)) &&
-             ((cycle1_ == -1) || (S_->get_cycle() <= cycle1_)) &&
-             ((duration_ < 0) || (wallclock_timer_->totalElapsedTime(true) < duration)) &&
-             (dt > 0.)) {
-        if (vo_->os_OK(Teuchos::VERB_LOW)) {
-          *vo_->os()
-            << "================================================================================"
-            << std::endl
-            << std::endl
-            << "Cycle = " << S_->get_cycle() << ",  Time [days] = " << std::setprecision(16)
-            << S_->get_time() / (60 * 60 * 24) << ",  dt [days] = " << std::setprecision(16)
-            << dt / (60 * 60 * 24) << std::endl
-            << "--------------------------------------------------------------------------------"
-            << std::endl;
-        }
-
-        S_->Assign<double>("dt", Amanzi::Tags::DEFAULT, "dt", dt);
-        S_->advance_time(Amanzi::Tags::NEXT, dt);
-        bool fail = advance();
-
-        if (fail) {
-          // reset t_new
-          S_->set_time(Amanzi::Tags::NEXT, S_->get_time(Amanzi::Tags::CURRENT));
-        } else {
-          S_->set_time(Amanzi::Tags::CURRENT, S_->get_time(Amanzi::Tags::NEXT));
-          S_->advance_cycle();
-
-          visualize();
-          observe();
-          checkpoint();
-        }
-
-        dt = get_dt(fail);
-      } // while not finished
-
+      time_advancer_->advance(t0_, t1_);
 #if !DEBUG_MODE
     } catch (Errors::TimestepCrash& e) {
       // write one more vis for help debugging
       S_->advance_cycle(Amanzi::Tags::NEXT);
-      visualize(true); // force vis
+      time_advancer_->visualize(true);
+      time_advancer_->observe();
 
-      // flush observations to make sure they are saved
-      for (const auto& obs : observations_) obs->Flush();
-
-      // dump a post_mortem checkpoint file for debugging
-      checkpoint_->set_filebasename("post_mortem");
-      checkpoint_->Write(*S_, Amanzi::Checkpoint::WriteType::POST_MORTEM);
+      // dump a post_mortem checkpoint for debugging
+      // TODO: expose post_mortem write through TimeAdvancer
       throw e;
     }
 #endif
@@ -188,7 +143,9 @@ ATSDriver::cycle_driver()
     reportOneTimer_("4: solve");
   }
 
-  // finalizing simulation
+  //
+  // finalize phase
+  // ----------------------------------------
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "================================================================================"
                << std::endl
@@ -200,19 +157,14 @@ ATSDriver::cycle_driver()
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("5: finalize");
   }
-} // cycle driver
+}
 
 
-// -----------------------------------------------------------------------------
-// run simulation
-// -----------------------------------------------------------------------------
 int
 ATSDriver::run()
 {
-  // run the simulation
-  cycle_driver();
+  cycle_driver_();
   return 0;
 }
-
 
 } // end namespace ATS

--- a/src/executables/ats_driver.hh
+++ b/src/executables/ats_driver.hh
@@ -10,9 +10,6 @@
 // Runs top-level time loop for standalone ATS simulations
 
 
-/* -*-  mode: c++; indent-tabs-mode: nil -*- */
-
-
 /*!
 
 ATS's top level driver is provided the entire input spec as a single list
@@ -31,7 +28,7 @@ called `"main`".  That list contains the following required elements:
    * `"state`" ``[state-spec]`` A :ref:`State` spec.
 
 
-Coordinator
+Cycle Driver
 ############
 
 In the `"cycle driver`" sublist, the user specifies global control of the
@@ -101,8 +98,7 @@ Example:
 #pragma once
 
 #include "Key.hh"
-#include "coordinator.hh"
-
+#include "driver.hh"
 
 namespace Amanzi {
 class State;
@@ -110,13 +106,15 @@ class State;
 
 namespace ATS {
 
-class ATSDriver : public Coordinator {
+class ATSDriver : public Driver {
  public:
-  using Coordinator::Coordinator;
+  using Driver::Driver;
 
-  // methods
-  void cycle_driver();
   int run();
+
+ private:
+  void cycle_driver_();
+  void createTimeAdvancer_();
 };
 
 } // namespace ATS

--- a/src/executables/ats_mesh_factory.cc
+++ b/src/executables/ats_mesh_factory.cc
@@ -11,6 +11,7 @@
 #include "Epetra_MpiComm.h"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_VerboseObject.hpp"
 #include "AmanziComm.hh"
 #include "AmanziTypes.hh"
 #include "Teuchos_ParameterXMLFileReader.hpp"
@@ -849,7 +850,7 @@ createMeshes(const Teuchos::RCP<Teuchos::ParameterList>& global_list,
     }
   }
 
-  Teuchos::TimeMonitor::summarize();
+  Teuchos::TimeMonitor::summarize(*Teuchos::VerboseObjectBase::getDefaultOStream());
   Teuchos::TimeMonitor::zeroOutTimers();
 }
 

--- a/src/executables/driver.cc
+++ b/src/executables/driver.cc
@@ -1,0 +1,383 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon
+*/
+
+#include <iomanip>
+#include <iostream>
+#include <unistd.h>
+#include <sys/resource.h>
+#include "errors.hh"
+
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_VerboseObjectParameterListHelpers.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_CommHelpers.hpp"
+
+#include "AmanziComm.hh"
+#include "AmanziTypes.hh"
+
+#include "InputAnalysis.hh"
+#include "Units.hh"
+#include "CompositeVector.hh"
+#include "TimeStepManager.hh"
+#include "MeshInfo.hh"
+#include "IO.hh"
+#include "GeometricModel.hh"
+#include "Checkpoint.hh"
+#include "State.hh"
+#include "PK.hh"
+#include "TreeVector.hh"
+#include "PK_Factory.hh"
+#include "PK_Helpers.hh"
+
+#include "Key.hh"
+#include "ats_mesh_factory.hh"
+#include "time_advancer.hh"
+#include "driver.hh"
+
+namespace ATS {
+
+Driver::Driver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
+               const Teuchos::RCP<Teuchos::Time>& wallclock_timer,
+               const Teuchos::RCP<const Teuchos::Comm<int>>& teuchos_comm,
+               const Amanzi::Comm_ptr_type& comm)
+  : plist_(plist),
+    teuchos_comm_(teuchos_comm),
+    comm_(comm),
+    restart_(false),
+    wallclock_timer_(wallclock_timer),
+    wallclock_monitor_(*wallclock_timer)
+{
+  coordinator_list_ = Teuchos::sublist(plist_, "cycle driver");
+  vo_ = Teuchos::rcp(new Amanzi::VerboseObject(comm_, "ATS", *coordinator_list_));
+  Teuchos::OSTab tab = vo_->getOSTab();
+
+  timers_["0: create mesh"] = Teuchos::TimeMonitor::getNewCounter("0: create mesh");
+  timers_["1: create run"] = Teuchos::TimeMonitor::getNewCounter("1: create run");
+  timers_["2a: parseParameterList"] = Teuchos::TimeMonitor::getNewCounter("2a: parseParameterList");
+  timers_["2b: setup"] = Teuchos::TimeMonitor::getNewCounter("2b: setup");
+  timers_["3: initialize"] = Teuchos::TimeMonitor::getNewCounter("3: initialize");
+  timers_["4: solve"] = Teuchos::TimeMonitor::getNewCounter("4: solve");
+  timers_["4a: advance step"] = Teuchos::TimeMonitor::getNewCounter("4a: advance step");
+  timers_["4b: visualize"] = Teuchos::TimeMonitor::getNewCounter("4b: visualize");
+  timers_["4c: observe"] = Teuchos::TimeMonitor::getNewCounter("4c: observe");
+  timers_["4d: checkpoint"] = Teuchos::TimeMonitor::getNewCounter("4d: checkpoint");
+  timers_["5: finalize"] = Teuchos::TimeMonitor::getNewCounter("5: finalize");
+
+  if (vo_->os_OK(Teuchos::VERB_LOW)) {
+    *vo_->os() << "Writing input file ..." << std::endl << std::endl;
+    Teuchos::writeParameterListToXmlOStream(*plist_, *vo_->os());
+    *vo_->os() << "  ... completed." << std::endl;
+  }
+
+  // construct state, geometric model, meshes
+  if (vo_->os_OK(Teuchos::VERB_LOW)) {
+    *vo_->os() << "================================================================================"
+               << std::endl
+               << "Beginning mesh creation stage..." << std::endl
+               << std::flush;
+  }
+  {
+    Teuchos::TimeMonitor timer(*timers_.at("0: create mesh"));
+    S_ = Teuchos::rcp(new Amanzi::State(plist_->sublist("state")));
+
+    Teuchos::ParameterList reg_list = plist_->sublist("regions");
+    Teuchos::RCP<Amanzi::AmanziGeometry::GeometricModel> gm =
+      Teuchos::rcp(new Amanzi::AmanziGeometry::GeometricModel(3, reg_list, *comm_));
+
+    ATS::Mesh::createMeshes(plist_, comm_, gm, *S_);
+  }
+  if (vo_->os_OK(Teuchos::VERB_LOW)) {
+    *vo_->os() << "  ... completed: ";
+    reportOneTimer_("0: create mesh");
+  }
+
+  // create PKs and supporting objects
+  if (vo_->os_OK(Teuchos::VERB_LOW)) {
+    *vo_->os() << "================================================================================"
+               << std::endl
+               << "Beginning run creation stage..." << std::endl
+               << std::flush;
+  }
+  {
+    Teuchos::TimeMonitor timer(*timers_.at("1: create run"));
+    initializeFromPlist_();
+
+    Teuchos::RCP<Teuchos::ParameterList> pks_list = Teuchos::sublist(plist_, "PKs");
+    Teuchos::ParameterList pk_tree_list = coordinator_list_->sublist("PK tree");
+    if (pk_tree_list.numParams() != 1) {
+      Errors::Message message("Driver: PK tree list should contain exactly one root node list");
+      Exceptions::amanzi_throw(message);
+    }
+    Teuchos::ParameterList::ConstIterator pk_item = pk_tree_list.begin();
+    const std::string& pk_name = pk_tree_list.name(pk_item);
+
+    soln_ = Teuchos::rcp(new Amanzi::TreeVector(comm_));
+
+    Amanzi::PKFactory pk_factory;
+    pk_ = pk_factory.CreatePK(pk_name, pk_tree_list, plist_, S_, soln_);
+
+    for (Amanzi::State::mesh_iterator mesh = S_->mesh_begin(); mesh != S_->mesh_end(); ++mesh) {
+      auto& mesh_sublist = plist_->sublist("mesh").sublist(mesh->first);
+      if (mesh_sublist.isSublist("region analysis")) {
+        Amanzi::InputAnalysis analysis(mesh->second.first, mesh->first);
+        analysis.Init(mesh_sublist.sublist("region analysis"));
+        analysis.RegionAnalysis();
+        analysis.OutputBCs();
+      }
+      if (mesh_sublist.isSublist("mesh info")) {
+        Teuchos::RCP<Amanzi::MeshInfo> mesh_info =
+          Teuchos::rcp(new Amanzi::MeshInfo(mesh_sublist.sublist("mesh info"), *S_));
+        mesh_info->WriteMeshCentroids(mesh->first, *(mesh->second.first));
+      }
+    }
+
+    // create the TimeStepManager
+    tsm_ = Teuchos::rcp(
+      new Amanzi::Utils::TimeStepManager(coordinator_list_->sublist("timestep manager")));
+    tsm_->RegisterTimeEvent(t1_);
+    if (coordinator_list_->isSublist("required times")) {
+      Teuchos::ParameterList& sublist = coordinator_list_->sublist("required times");
+      Amanzi::Utils::IOEvent pause_times(sublist);
+      pause_times.RegisterWithTimeStepManager(*tsm_);
+    }
+  }
+  if (vo_->os_OK(Teuchos::VERB_LOW)) {
+    *vo_->os() << "  ... completed: ";
+    reportOneTimer_("1: create run");
+  }
+}
+
+
+void
+Driver::parseParameterList()
+{
+  Teuchos::TimeMonitor monitor(*timers_.at("2a: parseParameterList"));
+
+  S_->require_time(Amanzi::Tags::CURRENT);
+  S_->require_time(Amanzi::Tags::NEXT);
+
+  pk_->set_tags(Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT);
+  pk_->parseParameterList();
+}
+
+
+void
+Driver::setup()
+{
+  Teuchos::TimeMonitor monitor(*timers_.at("2b: setup"));
+
+  S_->Require<double>("atmospheric_pressure", Amanzi::Tags::DEFAULT, "coordinator");
+  S_->Require<Amanzi::AmanziGeometry::Point>("gravity", Amanzi::Tags::DEFAULT, "coordinator");
+
+  // require vertex coordinates on Tags::NEXT for all deformable meshes so that
+  // Driver can initialize, suppress vis output, and handle checkpoint restart
+  // independently of any PK that may also require them on a different tag.
+  for (Amanzi::State::mesh_iterator mesh = S_->mesh_begin(); mesh != S_->mesh_end(); ++mesh) {
+    if (S_->IsDeformableMesh(mesh->first) && !S_->IsAliasedMesh(mesh->first)) {
+      Amanzi::Key node_key = Amanzi::Keys::getKey(mesh->first, "vertex_coordinates");
+      S_->Require<Amanzi::CompositeVector, Amanzi::CompositeVectorSpace>(
+        node_key, Amanzi::Tags::NEXT, node_key)
+        .SetMesh(mesh->second.first)
+        ->SetComponent("node", Amanzi::AmanziMesh::Entity_kind::NODE, mesh->second.first->getSpaceDimension());
+    }
+  }
+
+  // order matters: PK leaves first, then observations can use those fields,
+  // then State::Setup() allocates memory for all secondaries
+  pk_->Setup();
+  if (time_advancer_.get()) time_advancer_->setup();
+  S_->Setup();
+}
+
+
+void
+Driver::initialize()
+{
+  Teuchos::TimeMonitor monitor(*timers_.at("3: initialize"));
+  Teuchos::OSTab tab = vo_->getOSTab();
+
+  S_->set_time(Amanzi::Tags::CURRENT, t0_);
+  S_->set_time(Amanzi::Tags::NEXT, t0_);
+  S_->set_cycle(cycle0_);
+
+  if (restart_) {
+    double t_restart = Amanzi::ReadCheckpointInitialTime(comm_, restart_filename_);
+    for (const auto& record : S_->GetRecordSet("time")) {
+      S_->set_time(record.first, t_restart);
+    }
+    t0_ = t_restart;
+  }
+
+  S_->InitializeFields();
+  pk_->Initialize();
+  pk_->CommitStep(t0_, t0_, Amanzi::Tags::NEXT);
+
+  // initialize vertex coordinates and suppress vis (checkpoint handles them)
+  for (Amanzi::State::mesh_iterator mesh = S_->mesh_begin(); mesh != S_->mesh_end(); ++mesh) {
+    if (S_->IsDeformableMesh(mesh->first) && !S_->IsAliasedMesh(mesh->first)) {
+      Amanzi::Key node_key = Amanzi::Keys::getKey(mesh->first, "vertex_coordinates");
+      copyMeshCoordinatesToVector(
+        *mesh->second.first,
+        S_->GetW<Amanzi::CompositeVector>(node_key, Amanzi::Tags::NEXT, node_key));
+      S_->GetRecordW(node_key, Amanzi::Tags::NEXT, node_key).set_initialized();
+      S_->GetRecordW(node_key, Amanzi::Tags::NEXT, node_key).set_io_vis(false);
+    }
+  }
+
+  if (restart_) {
+    Amanzi::ReadCheckpoint(comm_, *S_, restart_filename_);
+    t0_ = S_->get_time();
+    cycle0_ = S_->get_cycle();
+
+    S_->set_time(Amanzi::Tags::CURRENT, t0_);
+    S_->set_time(Amanzi::Tags::NEXT, t0_);
+
+    for (Amanzi::State::mesh_iterator mesh = S_->mesh_begin(); mesh != S_->mesh_end(); ++mesh) {
+      if (S_->IsDeformableMesh(mesh->first) && !S_->IsAliasedMesh(mesh->first))
+        Amanzi::DeformCheckpointMesh(*S_, mesh->first);
+    }
+  }
+
+  S_->InitializeEvaluators();
+  S_->InitializeFieldCopies();
+  S_->CheckAllFieldsInitialized();
+  S_->InitializeIOFlags();
+
+  pk_->CommitStep(S_->get_time(), S_->get_time(), Amanzi::Tags::NEXT);
+
+  if (S_->get_cycle() == -1) S_->advance_cycle();
+
+  if (time_advancer_.get()) time_advancer_->initialize();
+}
+
+
+void
+Driver::finalize(bool checkpoint)
+{
+  Teuchos::TimeMonitor monitor(*timers_.at("5: finalize"));
+
+  pk_->CalculateDiagnostics(Amanzi::Tags::NEXT);
+  if (time_advancer_.get()) time_advancer_->finalize(checkpoint);
+  WriteStateStatistics(*S_, *vo_);
+  report_memory();
+}
+
+
+static double
+rss_usage()
+{
+#if (defined(__unix__) || defined(__unix) || defined(unix) || defined(__APPLE__) || \
+     defined(__MACH__))
+  struct rusage usage;
+  getrusage(RUSAGE_SELF, &usage);
+#if (defined(__APPLE__) || defined(__MACH__))
+  return static_cast<double>(usage.ru_maxrss) / 1024.0 / 1024.0;
+#else
+  return static_cast<double>(usage.ru_maxrss) / 1024.0;
+#endif
+#else
+  return 0.0;
+#endif
+}
+
+
+void
+Driver::report_memory()
+{
+  if (vo_->os_OK(Teuchos::VERB_MEDIUM)) {
+    double global_ncells(0.0);
+    double local_ncells(0.0);
+    for (Amanzi::State::mesh_iterator mesh = S_->mesh_begin(); mesh != S_->mesh_end(); ++mesh) {
+      Epetra_Map cell_map =
+        (mesh->second.first)->getMap(Amanzi::AmanziMesh::Entity_kind::CELL, false);
+      global_ncells += cell_map.NumGlobalElements();
+      local_ncells += cell_map.NumMyElements();
+    }
+
+    double mem = rss_usage();
+    double percell = (local_ncells > 0) ? mem / local_ncells : mem;
+
+    double max_percell(0.0), min_percell(0.0);
+    comm_->MinAll(&percell, &min_percell, 1);
+    comm_->MaxAll(&percell, &max_percell, 1);
+
+    double total_mem(0.0), max_mem(0.0), min_mem(0.0);
+    comm_->SumAll(&mem, &total_mem, 1);
+    comm_->MinAll(&mem, &min_mem, 1);
+    comm_->MaxAll(&mem, &max_mem, 1);
+
+    Teuchos::OSTab tab = vo_->getOSTab();
+    *vo_->os() << "--------------------------------------------------------------------------------"
+               << std::endl
+               << "All meshes combined have " << global_ncells << " cells." << std::endl
+               << "Memory usage (high water mark):" << std::endl
+               << std::fixed << std::setprecision(1) << "  Maximum per core:   " << std::setw(7)
+               << max_mem << " MBytes,  maximum per cell: " << std::setw(7)
+               << max_percell * 1024 * 1024 << " Bytes" << std::endl
+               << "  Minimum per core:   " << std::setw(7) << min_mem
+               << " MBytes,  minimum per cell: " << std::setw(7) << min_percell * 1024 * 1024
+               << " Bytes" << std::endl
+               << "  Total:              " << std::setw(7) << total_mem
+               << " MBytes,  total per cell:   " << std::setw(7)
+               << total_mem / global_ncells * 1024 * 1024 << " Bytes" << std::endl;
+  }
+}
+
+
+void
+Driver::initializeFromPlist_()
+{
+  Amanzi::Utils::Units units;
+  t0_ = coordinator_list_->get<double>("start time");
+  std::string t0_units = coordinator_list_->get<std::string>("start time units", "s");
+  if (!units.IsValidTime(t0_units)) {
+    Errors::Message msg;
+    msg << "Driver start time: unknown time units type: \"" << t0_units
+        << "\"  Valid are: " << units.ValidTimeStrings();
+    Exceptions::amanzi_throw(msg);
+  }
+  bool success;
+  t0_ = units.ConvertTime(t0_, t0_units, "s", success);
+
+  t1_ = coordinator_list_->get<double>("end time");
+  std::string t1_units = coordinator_list_->get<std::string>("end time units", "s");
+  if (!units.IsValidTime(t1_units)) {
+    Errors::Message msg;
+    msg << "Driver end time: unknown time units type: \"" << t1_units
+        << "\"  Valid are: " << units.ValidTimeStrings();
+    Exceptions::amanzi_throw(msg);
+  }
+  t1_ = units.ConvertTime(t1_, t1_units, "s", success);
+
+  cycle0_ = coordinator_list_->get<int>("start cycle", -1);
+
+  restart_ = coordinator_list_->isParameter("restart from checkpoint file");
+  if (restart_)
+    restart_filename_ = coordinator_list_->get<std::string>("restart from checkpoint file");
+}
+
+
+void
+Driver::reportOneTimer_(const std::string& timer_name)
+{
+  auto timer = timers_.at(timer_name);
+  double l_time = timer->totalElapsedTime();
+  double min_time, max_time, mean_time;
+  Teuchos::reduceAll(*teuchos_comm_, Teuchos::REDUCE_MIN, 1, &l_time, &min_time);
+  Teuchos::reduceAll(*teuchos_comm_, Teuchos::REDUCE_MAX, 1, &l_time, &max_time);
+  Teuchos::reduceAll(*teuchos_comm_, Teuchos::REDUCE_SUM, 1, &l_time, &mean_time);
+  mean_time = mean_time / teuchos_comm_->getSize();
+  if (vo_->os_OK(Teuchos::VERB_LOW)) {
+    *vo_->os() << min_time << " / " << mean_time << " / " << max_time << " (min/mean/max) [s]"
+               << std::endl;
+  }
+}
+
+} // namespace ATS

--- a/src/executables/driver.hh
+++ b/src/executables/driver.hh
@@ -1,0 +1,92 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon
+*/
+
+//! Base class for top-level ATS simulation drivers.
+/*!
+
+Driver is responsible for constructing meshes, State, and the PK hierarchy,
+and for driving the PK lifecycle (parseParameterList, setup, initialize,
+finalize).  Timestep advancement is delegated to TimeAdvancer.
+
+Subclasses add a run() method (ATSDriver) or expose a per-step advance()
+method (ELM_ATSDriver).
+
+*/
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "Teuchos_Time.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_Comm.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Epetra_MpiComm.h"
+#include "AmanziComm.hh"
+#include "AmanziTypes.hh"
+
+#include "VerboseObject.hh"
+
+namespace Amanzi {
+namespace Utils {
+class TimeStepManager;
+} // namespace Utils
+class State;
+class TreeVector;
+class PK;
+} // namespace Amanzi
+
+namespace ATS {
+
+class TimeAdvancer;
+
+class Driver {
+ public:
+  Driver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
+         const Teuchos::RCP<Teuchos::Time>& wallclock_timer,
+         const Teuchos::RCP<const Teuchos::Comm<int>>& teuchos_comm,
+         const Amanzi::Comm_ptr_type& comm);
+
+  virtual void parseParameterList();
+  virtual void setup();
+  virtual void initialize();
+  virtual void finalize(bool checkpoint = true);
+  void report_memory();
+
+ protected:
+  void initializeFromPlist_();
+  void reportOneTimer_(const std::string& timer);
+
+  Teuchos::RCP<Amanzi::PK> pk_;
+  Teuchos::RCP<Amanzi::State> S_;
+  Teuchos::RCP<Amanzi::TreeVector> soln_;
+  Teuchos::RCP<Amanzi::Utils::TimeStepManager> tsm_;
+  Teuchos::RCP<TimeAdvancer> time_advancer_;
+
+  Teuchos::RCP<Teuchos::ParameterList> plist_;
+  Teuchos::RCP<Teuchos::ParameterList> coordinator_list_;
+
+  double t0_, t1_;
+  int cycle0_;
+
+  bool restart_;
+  std::string restart_filename_;
+
+  Amanzi::Comm_ptr_type comm_;
+  Teuchos::RCP<const Teuchos::Comm<int>> teuchos_comm_;
+
+  std::map<std::string, Teuchos::RCP<Teuchos::Time>> timers_;
+  Teuchos::RCP<Teuchos::Time> wallclock_timer_;
+  Teuchos::TimeMonitor wallclock_monitor_;
+
+  Teuchos::RCP<Amanzi::VerboseObject> vo_;
+};
+
+} // namespace ATS

--- a/src/executables/elm_ats_api/CMakeLists.txt
+++ b/src/executables/elm_ats_api/CMakeLists.txt
@@ -14,14 +14,14 @@ FortranCInterface_VERIFY(CXX)
 include_directories(${ATS_SOURCE_DIR}/src/executables)
 
 set(elm_ats_src_files
-  ${ATS_SOURCE_DIR}/src/executables/coordinator.cc
+  ${ATS_SOURCE_DIR}/src/executables/driver.cc
   ${ATS_SOURCE_DIR}/src/executables/ats_mesh_factory.cc
   elm_ats_driver.cc
   elm_ats_api.cc
   )
 
 set(elm_ats_inc_files
-  ${ATS_SOURCE_DIR}/src/executables/coordinator.hh
+  ${ATS_SOURCE_DIR}/src/executables/driver.hh
   ${ATS_SOURCE_DIR}/src/executables/ats_mesh_factory.hh
   elm_ats_driver.hh
   elm_ats_api.h

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -68,7 +68,8 @@ ELM_ATSDriver::ELM_ATSDriver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
     npfts_(npfts),
     ncolumns(-1),
     ncells_per_col_(-1),
-    elm_plist_(Teuchos::sublist(Teuchos::sublist(plist, "cycle driver"), "ELM driver"))
+    elm_plist_(Teuchos::sublist(Teuchos::sublist(plist, "cycle driver"), "ELM driver")),
+    elm_cycle_(0)
 {
   // -- set default verbosity level to no output
   // -- TODO make the verbosity level an input argument
@@ -130,7 +131,7 @@ ELM_ATSDriver::parseParameterList()
   // actual water fluxes
   evap_key_ = Keys::readKey(*elm_plist_, domain_surf_, "evaporation", "evaporation");
   key_map_[ELM::VarID::EVAPORATION] = { evap_key_, Tags::NEXT };
-  col_trans_key_ = Keys::readKey(*elm_plist_, domain_surf_, "total transpiration", "total_transpiration");
+  col_trans_key_ = Keys::readKey(*elm_plist_, domain_surf_, "surface transpiration", "transpiration");
   key_map_[ELM::VarID::TRANSPIRATION] = { col_trans_key_, Tags::NEXT };
   col_baseflow_key_ = Keys::readKey(*elm_plist_, domain_surf_, "baseflow generation", "baseflow_mps");
   key_map_[ELM::VarID::BASEFLOW] = { col_baseflow_key_, Tags::NEXT };
@@ -167,9 +168,10 @@ ELM_ATSDriver::parseParameterList()
   // before State::Setup() allocates memory.
   // ELM controls checkpointing, so no checkpoint sublist.
   time_advancer_ = Teuchos::rcp(new ATS::TimeAdvancer(
-    elm_plist_, S_, pk_, tsm_,
-    Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT,
-    vo_, wallclock_timer_));
+            Teuchos::sublist(plist_, "cycle driver"),
+            S_, pk_, tsm_,
+            Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT,
+            vo_, wallclock_timer_));
 
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
@@ -342,19 +344,19 @@ void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
     AMANZI_ASSERT(std::abs(S_->get_time(Amanzi::Tags::NEXT) - S_->get_time(Amanzi::Tags::CURRENT)) <
                   1.e-4);
 
+    double t_now = S_->get_time(Amanzi::Tags::CURRENT);
+
     if (vo_->os_OK(Teuchos::VERB_LOW)) {
       *vo_->os()
         << "================================================================================"
         << std::endl
         << std::endl
-        << "Cycle = " << S_->get_cycle() << ",  Time [days] = " << std::setprecision(16)
-        << S_->get_time() / (60 * 60 * 24) << ",  dt [days] = " << std::setprecision(16)
+        << "ELM Cycle = " << elm_cycle_ << ",  Time [days] = " << std::setprecision(16)
+        << t_now / (60 * 60 * 24) << ",  dt [days] = " << std::setprecision(16)
         << dt / (60 * 60 * 24) << std::endl
-        << "--------------------------------------------------------------------------------"
+        << "================================================================================"
         << std::endl;
     }
-
-    double t_now = S_->get_time(Amanzi::Tags::CURRENT);
 
     // convert ELM water content units to ATS units before solving.
     //
@@ -393,6 +395,8 @@ void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("4: solve");
   }
+
+  ++elm_cycle_;
 }
 
 

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -50,11 +50,17 @@ createELM_ATSDriver(MPI_Fint *f_comm, const char *infile, const char *logfile, i
       std::cerr << "ERROR: input file \"" << input_filename << "\" does not exist." << std::endl;
   }
 
+  // Set global logfile before constructing the driver so that the Driver base
+  // class constructor (which creates VerboseObjects) already sees the correct
+  // logfile path rather than falling back to stdout.
+  VerboseObject::global_default_level = Teuchos::VERB_LOW;
+  VerboseObject::global_logfile = logfile_filename;
+
   // -- parse input file
   Teuchos::RCP<Teuchos::ParameterList> plist = Teuchos::getParametersFromXmlFile(input_filename);
 
   auto wallclock_timer = Teuchos::TimeMonitor::getNewCounter("wallclock duration");
-  return new ELM_ATSDriver(plist, wallclock_timer, teuchos_comm, comm, logfile_filename, npfts);
+  return new ELM_ATSDriver(plist, wallclock_timer, teuchos_comm, comm, npfts);
 }
 
 
@@ -62,7 +68,6 @@ ELM_ATSDriver::ELM_ATSDriver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
                              const Teuchos::RCP<Teuchos::Time>& wallclock_timer,
                              const Teuchos::RCP<const Teuchos::Comm<int>>& teuchos_comm,
                              const Amanzi::Comm_ptr_type& comm,
-                             const std::string& logfile,
                              int npfts)
   : Driver(plist, wallclock_timer, teuchos_comm, comm),
     npfts_(npfts),
@@ -71,10 +76,6 @@ ELM_ATSDriver::ELM_ATSDriver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
     elm_plist_(Teuchos::sublist(Teuchos::sublist(plist, "cycle driver"), "ELM driver")),
     elm_cycle_(0)
 {
-  // -- set default verbosity level to no output
-  // -- TODO make the verbosity level an input argument
-  VerboseObject::global_default_level = Teuchos::VERB_HIGH;
-  VerboseObject::global_logfile = logfile;
 
   if (plist_->isSublist("visualization")) {
     auto vis_list = Teuchos::sublist(plist_, "visualization");
@@ -127,15 +128,13 @@ ELM_ATSDriver::setupIntegratedFlux_(const Key& flux_key, ELM::VarID varid)
 {
   Key integrated_key = flux_key + "_step_integrated";
 
-  // inject EvaluatorTimeAccumulated into state/evaluators if not user-provided
-  if (!S_->HasEvaluatorList(integrated_key)) {
-    auto& ep = S_->GetEvaluatorList(integrated_key);
-    ep.set("evaluator type", "time accumulated");
-    ep.set("tag", Amanzi::Tags::NEXT.get());
-    ep.set("accumulated key", flux_key);
-    ep.set("accumulated tag", Amanzi::Tags::NEXT.get());
-    ep.set("accumulation type", "integral");
-  }
+  // inject EvaluatorTimeAccumulated into state/evaluators
+  auto& ep = S_->GetEvaluatorList(integrated_key);
+  ep.set("evaluator type", "time accumulated");
+  ep.set("tag", Amanzi::Tags::NEXT.get());
+  ep.set("accumulated key", flux_key);
+  ep.set("accumulated tag", Amanzi::Tags::NEXT.get());
+  ep.set("accumulation type", "integral");
 
   // append to "time accumulators" in cycle driver plist
   auto& cd_list = plist_->sublist("cycle driver");

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -22,6 +22,7 @@
 #include "IO.hh"
 #include "UnstructuredObservations.hh"
 #include "PK_Helpers.hh"
+#include "time_advancer.hh"
 #include "elm_ats_driver.hh"
 
 namespace ATS {
@@ -63,7 +64,7 @@ ELM_ATSDriver::ELM_ATSDriver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
                              const Amanzi::Comm_ptr_type& comm,
                              const std::string& logfile,
                              int npfts)
-  : Coordinator(plist, wallclock_timer, teuchos_comm, comm),
+  : Driver(plist, wallclock_timer, teuchos_comm, comm),
     npfts_(npfts),
     ncolumns(-1),
     ncells_per_col_(-1),
@@ -160,7 +161,16 @@ ELM_ATSDriver::parseParameterList()
   requireEvaluatorAtNext(pot_evap_key_, Amanzi::Tags::NEXT, *S_, pot_evap_key_);
   requireEvaluatorAtNext(pot_trans_key_, Amanzi::Tags::NEXT, *S_, pot_trans_key_);
 
-  Coordinator::parseParameterList();
+  Driver::parseParameterList();
+
+  // construct TimeAdvancer here so time_advancer_->setup() is called in Driver::setup()
+  // before State::Setup() allocates memory.
+  // ELM controls checkpointing, so no checkpoint sublist.
+  time_advancer_ = Teuchos::rcp(new ATS::TimeAdvancer(
+    elm_plist_, S_, pk_, tsm_,
+    Amanzi::Tags::CURRENT, Amanzi::Tags::NEXT,
+    vo_, wallclock_timer_));
+
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("2a: parseParameterList");
@@ -238,7 +248,7 @@ ELM_ATSDriver::setup()
 
   // This must be last always -- it allocates memory calling State::setup, so
   // all other setup must be done.
-  Coordinator::setup();
+  Driver::setup();
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("2b: setup");
@@ -312,12 +322,9 @@ void ELM_ATSDriver::initialize()
   initValue_(col_baseflow_key_);
   initValue_(col_runoff_key_);
 
-  // initialize ATS data, commit initial conditions
-  Coordinator::initialize();
-
-  // visualization at IC -- TODO remove this or place behind flag
-  visualize();
-  checkpoint();
+  // initialize ATS data, commit initial conditions; TimeAdvancer::initialize()
+  // backs up mesh coordinates and dumps IC vis/obs (no IC checkpoint for ELM).
+  Driver::initialize();
 
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
@@ -347,18 +354,9 @@ void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
         << std::endl;
     }
 
-    // get the dt from ATS, as this may do some internal work that still needs to happen
-    double dt_ats = Coordinator::get_dt(false);
+    double t_now = S_->get_time(Amanzi::Tags::CURRENT);
 
-    // but we ignore it and use the requested ELM dt, expecting subcycling or similar to happen
-    S_->Assign<double>("dt", Amanzi::Tags::DEFAULT, "dt", dt);
-    S_->advance_time(Amanzi::Tags::NEXT, dt);
-
-    // old water_contents are set by ELM, using ELM units.  Change them to ATS units
-    //
-    // NOTE: the change in units is done here, and not in evaluators like
-    // inputs (e.g. transpiration_mps), because WC evaluators are expected to be
-    // primary by flow PKs, and then get overwritten here.
+    // convert ELM water content units to ATS units before solving.
     //
     // NOTE: these were just marked as changed in a call to getFieldPtrW so no
     // need to mark them as changed again.
@@ -384,19 +382,12 @@ void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
       }
     }
 
-    // solve model for a single timestep
-    bool fail = Coordinator::advance();
+    // advance from t_now to t_now+dt; TimeAdvancer handles subcycling internally
+    bool fail = time_advancer_->advance(t_now, t_now + dt);
     if (fail) {
       Errors::Message msg("ELM_ATSDriver: advance(dt) failed.  Make ATS subcycle for proper ELM use.");
       Exceptions::amanzi_throw(msg);
     }
-
-    S_->set_time(Amanzi::Tags::CURRENT, S_->get_time(Amanzi::Tags::NEXT));
-    S_->advance_cycle();
-
-    visualize(force_vis);
-    checkpoint(force_chkp);
-    observe();
   }
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
@@ -410,7 +401,7 @@ void ELM_ATSDriver::advanceTest()
 {
   while (S_->get_time() < t1_) {
     // use dt from ATS for testing
-    double dt = Coordinator::get_dt(false);
+    double dt = pk_->get_dt();
     // call main method
     advance(dt, false, false);
   }
@@ -424,7 +415,7 @@ void ELM_ATSDriver::finalize()
                << "Beginning finalize stage..." << std::endl
                << std::flush;
   }
-  Coordinator::finalize();
+  Driver::finalize(false);
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("5: finalize");

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <fstream>
 #include <unistd.h>
 #include <sys/resource.h>
 #include <filesystem>
@@ -50,11 +51,15 @@ createELM_ATSDriver(MPI_Fint *f_comm, const char *infile, const char *logfile, i
       std::cerr << "ERROR: input file \"" << input_filename << "\" does not exist." << std::endl;
   }
 
-  // Set global logfile before constructing the driver so that the Driver base
-  // class constructor (which creates VerboseObjects) already sees the correct
-  // logfile path rather than falling back to stdout.
   VerboseObject::global_default_level = Teuchos::VERB_LOW;
-  VerboseObject::global_logfile = logfile_filename;
+
+  // Open the ATS logfile once and install it as the Teuchos default ostream so
+  // that all VerboseObjects share one file descriptor and writes are ordered.
+  if (!logfile_filename.empty()) {
+    auto fos = Teuchos::fancyOStream(Teuchos::rcp(new std::ofstream(logfile_filename)));
+    fos->setOutputToRootOnly(VerboseObject::global_writing_rank);
+    Teuchos::VerboseObjectBase::setDefaultOStream(fos);
+  }
 
   // -- parse input file
   Teuchos::RCP<Teuchos::ParameterList> plist = Teuchos::getParametersFromXmlFile(input_filename);

--- a/src/executables/elm_ats_api/elm_ats_driver.cc
+++ b/src/executables/elm_ats_api/elm_ats_driver.cc
@@ -75,12 +75,86 @@ ELM_ATSDriver::ELM_ATSDriver(const Teuchos::RCP<Teuchos::ParameterList>& plist,
   // -- TODO make the verbosity level an input argument
   VerboseObject::global_default_level = Teuchos::VERB_HIGH;
   VerboseObject::global_logfile = logfile;
+
+  if (plist_->isSublist("visualization")) {
+    auto vis_list = Teuchos::sublist(plist_, "visualization");
+    for (auto& entry : *vis_list) {
+      std::string domain_name = entry.first;
+      if (S_->HasMesh(domain_name)) {
+        auto mesh_p = S_->GetMesh(domain_name);
+        auto sublist_p = Teuchos::sublist(vis_list, domain_name);
+        if (!sublist_p->isParameter("file name base")) {
+          if (domain_name.empty() || domain_name == "domain") {
+            sublist_p->set<std::string>("file name base", std::string("ats_vis"));
+          } else {
+            sublist_p->set<std::string>("file name base", std::string("ats_vis_") + domain_name);
+          }
+        }
+        if (S_->HasMesh(domain_name + "_3d") && sublist_p->get<bool>("visualize on 3D mesh", true))
+          mesh_p = S_->GetMesh(domain_name + "_3d");
+        auto vis = Teuchos::rcp(new Amanzi::Visualization(*sublist_p));
+        vis->set_name(domain_name);
+        vis->set_mesh(mesh_p);
+        vis->CreateFiles(false);
+        visualization_.push_back(vis);
+      }
+    }
+  }
+}
+
+
+bool
+ELM_ATSDriver::visualize_(bool force)
+{
+  bool dump = force;
+  double time = S_->get_time();
+  int cycle = elm_cycle_;
+
+  if (!dump) {
+    for (const auto& vis : visualization_) dump |= vis->DumpRequested(cycle, time);
+  }
+  if (dump) pk_->CalculateDiagnostics(Tags::NEXT);
+  for (const auto& vis : visualization_) {
+    if (force || vis->DumpRequested(cycle, time)) WriteVis(*vis, *S_);
+  }
+  return dump;
+}
+
+
+
+Key
+ELM_ATSDriver::setupIntegratedFlux_(const Key& flux_key, ELM::VarID varid)
+{
+  Key integrated_key = flux_key + "_step_integrated";
+
+  // inject EvaluatorTimeAccumulated into state/evaluators if not user-provided
+  if (!S_->HasEvaluatorList(integrated_key)) {
+    auto& ep = S_->GetEvaluatorList(integrated_key);
+    ep.set("evaluator type", "time accumulated");
+    ep.set("tag", Amanzi::Tags::NEXT.get());
+    ep.set("accumulated key", flux_key);
+    ep.set("accumulated tag", Amanzi::Tags::NEXT.get());
+    ep.set("accumulation type", "integral");
+  }
+
+  // append to "time accumulators" in cycle driver plist
+  auto& cd_list = plist_->sublist("cycle driver");
+  auto acc_list = cd_list.get<Teuchos::Array<std::string>>(
+    "time accumulators", Teuchos::Array<std::string>());
+  acc_list.push_back(integrated_key + "@");
+  cd_list.set("time accumulators", acc_list);
+
+  // update key_map_ to point at the integrated quantity
+  key_map_[varid] = { integrated_key, Amanzi::Tags::NEXT };
+
+  return integrated_key;
 }
 
 
 void
 ELM_ATSDriver::parseParameterList()
 {
+  Teuchos::OSTab tab = vo_->getOSTab();
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "================================================================================"
                << std::endl
@@ -99,8 +173,8 @@ ELM_ATSDriver::parseParameterList()
   key_map_[ELM::VarID::TIME] = {"time", Tags::NEXT};
 
   // parameters
-  poro_key_ = Keys::readKey(*elm_plist_, domain_subsurf_, "porosity", "porosity");
-  key_map_[ELM::VarID::EFFECTIVE_POROSITY] = { poro_key_, Tags::NEXT };
+  base_poro_key_ = Keys::readKey(*elm_plist_, domain_subsurf_, "base porosity", "base_porosity");
+  key_map_[ELM::VarID::BASE_POROSITY] = { base_poro_key_, Tags::NEXT };
 
   // potential sources
   gross_water_source_key_ = Keys::readKey(*elm_plist_, domain_surf_, "gross water source", "gross_water_source");
@@ -123,20 +197,26 @@ ELM_ATSDriver::parseParameterList()
   surf_wc_key_ = Keys::readKey(*elm_plist_, domain_surf_, "surface water content", "water_content");
   key_map_[ELM::VarID::SURFACE_WATER_CONTENT_OLD] = { surf_wc_key_, Tags::CURRENT };
   wc_key_ = Keys::readKey(*elm_plist_, domain_subsurf_, "water content", "water_content");
+  key_map_[ELM::VarID::WATER_CONTENT] = { wc_key_, Tags::NEXT };
   key_map_[ELM::VarID::WATER_CONTENT_OLD] = { wc_key_, Tags::CURRENT };
 
   lat_key_ = Keys::readKey(*elm_plist_, domain_surf_, "latitude", "latitude");
   lon_key_ = Keys::readKey(*elm_plist_, domain_surf_, "longitude", "longitude");
 
-  // actual water fluxes
-  evap_key_ = Keys::readKey(*elm_plist_, domain_surf_, "evaporation", "evaporation");
-  key_map_[ELM::VarID::EVAPORATION] = { evap_key_, Tags::NEXT };
-  col_trans_key_ = Keys::readKey(*elm_plist_, domain_surf_, "surface transpiration", "transpiration");
-  key_map_[ELM::VarID::TRANSPIRATION] = { col_trans_key_, Tags::NEXT };
-  col_baseflow_key_ = Keys::readKey(*elm_plist_, domain_surf_, "baseflow generation", "baseflow_mps");
-  key_map_[ELM::VarID::BASEFLOW] = { col_baseflow_key_, Tags::NEXT };
-  col_runoff_key_ = Keys::readKey(*elm_plist_, domain_surf_, "runoff generation", "runoff_generation_mps");
-  key_map_[ELM::VarID::RUNOFF] = { col_runoff_key_, Tags::NEXT };
+  // actual water fluxes — each is wrapped in an EvaluatorTimeAccumulated so
+  // that the value returned to ELM is integrated over the outer timestep
+  evap_key_ = setupIntegratedFlux_(
+    Keys::readKey(*elm_plist_, domain_surf_, "evaporation", "evaporation"),
+    ELM::VarID::EVAPORATION);
+  col_trans_key_ = setupIntegratedFlux_(
+    Keys::readKey(*elm_plist_, domain_surf_, "surface transpiration", "transpiration"),
+    ELM::VarID::TRANSPIRATION);
+  col_baseflow_key_ = setupIntegratedFlux_(
+    Keys::readKey(*elm_plist_, domain_surf_, "baseflow generation", "baseflow_mps"),
+    ELM::VarID::BASEFLOW);
+  col_runoff_key_ = setupIntegratedFlux_(
+    Keys::readKey(*elm_plist_, domain_surf_, "runoff generation", "runoff_generation_mps"),
+    ELM::VarID::RUNOFF);
 
   // keys for fields used to convert ELM units to ATS units
   surf_mol_dens_key_ = Keys::readKey(*elm_plist_, domain_surf_, "surface molar density", "molar_density_liquid");
@@ -155,7 +235,7 @@ ELM_ATSDriver::parseParameterList()
 
   // require my primary variables
   // parameters set by ELM
-  requireEvaluatorAtNext(poro_key_, Amanzi::Tags::NEXT, *S_, poro_key_);
+  requireEvaluatorAtNext(base_poro_key_, Amanzi::Tags::NEXT, *S_, base_poro_key_);
 
   // potential fluxes (ELM -> ATS)
   requireEvaluatorAtNext(gross_water_source_key_, Amanzi::Tags::NEXT, *S_, gross_water_source_key_);
@@ -183,6 +263,7 @@ ELM_ATSDriver::parseParameterList()
 void
 ELM_ATSDriver::setup()
 {
+  Teuchos::OSTab tab = vo_->getOSTab();
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "================================================================================"
                << std::endl
@@ -203,7 +284,7 @@ ELM_ATSDriver::setup()
 
   // ELM --> ATS variables
   // -- parameters set by ELM
-  requireEvaluatorAtNext(poro_key_, Amanzi::Tags::NEXT, *S_, poro_key_)
+  requireEvaluatorAtNext(base_poro_key_, Amanzi::Tags::NEXT, *S_, base_poro_key_)
     .SetMesh(mesh_subsurf_)->SetComponent("cell", AmanziMesh::CELL, 1);
 
   // -- potential fluxes
@@ -219,6 +300,12 @@ ELM_ATSDriver::setup()
   requireEvaluatorAtCurrent(wc_key_, Amanzi::Tags::CURRENT, *S_)
     .SetMesh(mesh_subsurf_)->AddComponent("cell", AmanziMesh::CELL, 1);
   requireEvaluatorAtCurrent(surf_wc_key_, Amanzi::Tags::CURRENT, *S_)
+    .SetMesh(mesh_surf_)->AddComponent("cell", AmanziMesh::CELL, 1);
+
+  // save a copy for debugging!
+  requireEvaluatorAtCurrent("elm_old_water_content", Amanzi::Tags::NEXT, *S_, "elm_old_water_content")
+    .SetMesh(mesh_subsurf_)->AddComponent("cell", AmanziMesh::CELL, 1);
+  requireEvaluatorAtCurrent("surface-elm_old_water_content", Amanzi::Tags::NEXT, *S_, "surface-elm_old_water_content")
     .SetMesh(mesh_surf_)->AddComponent("cell", AmanziMesh::CELL, 1);
 
   // ATS --> ELM variables
@@ -305,6 +392,7 @@ ELM_ATSDriver::MeshInfo ELM_ATSDriver::getMeshInfo()
 
 void ELM_ATSDriver::initialize()
 {
+  Teuchos::OSTab tab = vo_->getOSTab();
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "================================================================================"
                << std::endl
@@ -313,7 +401,11 @@ void ELM_ATSDriver::initialize()
   }
 
   // some parameters have been initialized in ELM
-  S_->GetRecordW(poro_key_, Tags::NEXT, poro_key_).set_initialized();
+  S_->GetRecordW(base_poro_key_, Tags::NEXT, base_poro_key_).set_initialized();
+
+  // for debugging
+  initValue_("elm_old_water_content");
+  initValue_("surface-elm_old_water_content");
 
   // set as zero and tag as initialized
   initValue_(gross_water_source_key_);
@@ -328,6 +420,18 @@ void ELM_ATSDriver::initialize()
   // backs up mesh coordinates and dumps IC vis/obs (no IC checkpoint for ELM).
   Driver::initialize();
 
+  // initialize has to convert IC for water content into ELM units
+  // convert ATS water content units [mol] to ELM units [m^3 water per m^3 volume] before returning control to ELM
+  {
+    auto& wc = *S_->GetW<CompositeVector>(wc_key_, Tags::NEXT,
+            S_->GetRecord(wc_key_, Tags::NEXT).owner()).ViewComponent("cell", false);
+    const auto& cv = *S_->Get<CompositeVector>(cv_key_, Tags::NEXT).ViewComponent("cell", false);
+    const auto& n_liq = *S_->Get<CompositeVector>(mol_dens_key_, Tags::NEXT).ViewComponent("cell", false);
+    for (int c = 0; c != wc.MyLength(); ++c) {
+      wc[0][c] = wc[0][c] / cv[0][c] / n_liq[0][c];
+    }
+  }
+
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "  ... completed: ";
     reportOneTimer_("3: initialize");
@@ -338,6 +442,7 @@ void ELM_ATSDriver::initialize()
 
 void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
 {
+  Teuchos::OSTab tab = vo_->getOSTab();
   {
     Teuchos::TimeMonitor timer(*timers_.at("4: solve"));
 
@@ -358,7 +463,7 @@ void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
         << std::endl;
     }
 
-    // convert ELM water content units to ATS units before solving.
+    // convert ELM water content units [m^3 water per m^3 volume] to ATS units [mol] before solving.
     //
     // NOTE: these were just marked as changed in a call to getFieldPtrW so no
     // need to mark them as changed again.
@@ -384,11 +489,38 @@ void ELM_ATSDriver::advance(double dt, bool force_chkp, bool force_vis)
       }
     }
 
+    // -- save the old values in a new vector so they show up in vis for debugging
+    {
+      const auto& wc = *S_->Get<CompositeVector>(wc_key_, Tags::CURRENT).ViewComponent("cell", false);
+      auto& wc_old = *S_->GetW<CompositeVector>("elm_old_water_content", Tags::NEXT, "elm_old_water_content")
+        .ViewComponent("cell", false);
+      wc_old = wc;
+
+      const auto& surf_wc = *S_->Get<CompositeVector>(surf_wc_key_, Tags::CURRENT).ViewComponent("cell", false);
+      auto& surf_wc_old = *S_->GetW<CompositeVector>("surface-elm_old_water_content", Tags::NEXT, "surface-elm_old_water_content")
+        .ViewComponent("cell", false);
+      surf_wc_old = surf_wc;
+    }
+
     // advance from t_now to t_now+dt; TimeAdvancer handles subcycling internally
     bool fail = time_advancer_->advance(t_now, t_now + dt);
     if (fail) {
       Errors::Message msg("ELM_ATSDriver: advance(dt) failed.  Make ATS subcycle for proper ELM use.");
       Exceptions::amanzi_throw(msg);
+    }
+
+    // potentially visualize
+    visualize_();
+
+    // convert ATS water content units [mol] to ELM units [m^3 water per m^3 volume] before returning control to ELM
+    {
+      auto& wc = *S_->GetW<CompositeVector>(wc_key_, Tags::NEXT,
+              S_->GetRecord(wc_key_, Tags::NEXT).owner()).ViewComponent("cell", false);
+      const auto& cv = *S_->Get<CompositeVector>(cv_key_, Tags::NEXT).ViewComponent("cell", false);
+      const auto& n_liq = *S_->Get<CompositeVector>(mol_dens_key_, Tags::NEXT).ViewComponent("cell", false);
+      for (int c = 0; c != wc.MyLength(); ++c) {
+        wc[0][c] = wc[0][c] / cv[0][c] / n_liq[0][c];
+      }
     }
   }
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
@@ -413,6 +545,7 @@ void ELM_ATSDriver::advanceTest()
 
 void ELM_ATSDriver::finalize()
 {
+  Teuchos::OSTab tab = vo_->getOSTab();
   if (vo_->os_OK(Teuchos::VERB_LOW)) {
     *vo_->os() << "================================================================================"
                << std::endl

--- a/src/executables/elm_ats_api/elm_ats_driver.hh
+++ b/src/executables/elm_ats_api/elm_ats_driver.hh
@@ -14,6 +14,7 @@
 #include "Mesh.hh"
 #include "MeshPartition.hh"
 #include "Key.hh"
+#include "Visualization.hh"
 #include "driver.hh"
 
 #include "ats_variables.hh"
@@ -61,6 +62,11 @@ class ELM_ATSDriver : public Driver {
 
  private:
   void initValue_(const Key& key, double value = 0.);
+  bool visualize_(bool force = false);
+
+  // Wraps a raw flux key with an EvaluatorTimeAccumulated that integrates it
+  // over the outer ELM timestep.  Returns the integrated key.
+  Key setupIntegratedFlux_(const Key& flux_key, ELM::VarID varid);
 
  private:
   Teuchos::RCP<Teuchos::ParameterList> elm_plist_;
@@ -74,7 +80,7 @@ class ELM_ATSDriver : public Driver {
   Teuchos::RCP<const AmanziMesh::Mesh> mesh_subsurf_;
   Teuchos::RCP<const AmanziMesh::Mesh> mesh_surf_;
 
-  Key poro_key_;
+  Key base_poro_key_;
 
   Key gross_water_source_key_;
   Key pot_evap_key_;
@@ -106,7 +112,7 @@ class ELM_ATSDriver : public Driver {
   std::map<ELM::VarID, KeyTag> key_map_;
 
   int elm_cycle_;
-
+  std::vector<Teuchos::RCP<Amanzi::Visualization>> visualization_;
 };
 
 

--- a/src/executables/elm_ats_api/elm_ats_driver.hh
+++ b/src/executables/elm_ats_api/elm_ats_driver.hh
@@ -14,7 +14,7 @@
 #include "Mesh.hh"
 #include "MeshPartition.hh"
 #include "Key.hh"
-#include "coordinator.hh"
+#include "driver.hh"
 
 #include "ats_variables.hh"
 
@@ -22,7 +22,7 @@ namespace ATS {
 
 using namespace Amanzi;
 
-class ELM_ATSDriver : public Coordinator {
+class ELM_ATSDriver : public Driver {
 
  public:
 

--- a/src/executables/elm_ats_api/elm_ats_driver.hh
+++ b/src/executables/elm_ats_api/elm_ats_driver.hh
@@ -41,7 +41,6 @@ class ELM_ATSDriver : public Driver {
                 const Teuchos::RCP<Teuchos::Time>& wallclock_timer,
                 const Teuchos::RCP<const Teuchos::Comm<int>>& teuchos_comm,
                 const Amanzi::Comm_ptr_type& comm,
-                const std::string& logfile,
                 int npfts = 17);
 
   MeshInfo getMeshInfo();

--- a/src/executables/elm_ats_api/elm_ats_driver.hh
+++ b/src/executables/elm_ats_api/elm_ats_driver.hh
@@ -105,6 +105,8 @@ class ELM_ATSDriver : public Driver {
 
   std::map<ELM::VarID, KeyTag> key_map_;
 
+  int elm_cycle_;
+
 };
 
 

--- a/src/pks/CMakeLists.txt
+++ b/src/pks/CMakeLists.txt
@@ -6,6 +6,7 @@
 #
 include_directories(${GEOCHEM_SOURCE_DIR})
 include_directories(${CHEMPK_SOURCE_DIR})
+include_directories(${ATS_SOURCE_DIR}/src/constitutive_relations/generic_evaluators)
 
 set(ats_pks_src_files
   chem_pk_helpers.cc
@@ -39,6 +40,7 @@ set(ats_pks_link_libs
   state
   time_integration
   pks
+  ats_generic_evals
   )
 
 

--- a/src/pks/CMakeLists.txt
+++ b/src/pks/CMakeLists.txt
@@ -13,6 +13,7 @@ set(ats_pks_src_files
   pk_physical_bdf_default.cc
   pk_explicit_default.cc
   bc_factory.cc
+  time_advancer.cc
   )
 
 set(ats_pks_inc_files

--- a/src/pks/mpc/mpc_coupled_water_split_flux.cc
+++ b/src/pks/mpc/mpc_coupled_water_split_flux.cc
@@ -7,6 +7,7 @@
   Authors: Ethan Coon
 */
 
+#include "time_advancer.hh"
 #include "mpc_coupled_water_split_flux.hh"
 #include "mpc_surface_subsurface_helpers.hh"
 #include "PK_Helpers.hh"
@@ -117,9 +118,25 @@ MPCCoupledWaterSplitFlux::Setup()
 void
 MPCCoupledWaterSplitFlux::Initialize()
 {
+  // Set subcycled tag times (normally done in MPCSubcycled::Initialize)
+  int i = 0;
+  for (const auto& tag : tags_) {
+    if (subcycling_[i]) {
+      S_->set_time(tag.first, S_->get_time(Amanzi::Tags::CURRENT));
+      S_->set_time(tag.second, S_->get_time(Amanzi::Tags::NEXT));
+    }
+    ++i;
+  }
+
+  // Custom sub-PK ordering: subsurface first, copy to star, then star PK.
+  // Cannot use MPC<PK>::Initialize() which iterates in declared order.
   sub_pks_[1]->Initialize();
   CopyPrimaryToStar_();
   sub_pks_[0]->Initialize();
+
+  // Initialize TimeAdvancers (sets dt initialized, IC vis/obs, mesh coord backup)
+  for (auto& ta : time_advancers_)
+    if (ta.get()) ta->initialize();
 
   // FIXME -- this order is logically wrong but currently necessary.  The
   // intention is the following initialization process:
@@ -154,11 +171,6 @@ MPCCoupledWaterSplitFlux::Initialize()
     }
   }
 
-  int i = 0;
-  for (const auto& tag : tags_) {
-    if (subcycling_[i]) S_->GetRecordW("dt", tag.second, name()).set_initialized();
-    ++i;
-  }
 }
 
 

--- a/src/pks/mpc/mpc_permafrost_split_flux.cc
+++ b/src/pks/mpc/mpc_permafrost_split_flux.cc
@@ -7,6 +7,7 @@
   Authors: Ethan Coon
 */
 
+#include "time_advancer.hh"
 #include "mpc_permafrost_split_flux.hh"
 #include "mpc_surface_subsurface_helpers.hh"
 #include "PK_Helpers.hh"
@@ -203,9 +204,25 @@ MPCPermafrostSplitFlux::Setup()
 void
 MPCPermafrostSplitFlux::Initialize()
 {
+  // Set subcycled tag times (normally done in MPCSubcycled::Initialize)
+  int i = 0;
+  for (const auto& tag : tags_) {
+    if (subcycling_[i]) {
+      S_->set_time(tag.first, S_->get_time(Amanzi::Tags::CURRENT));
+      S_->set_time(tag.second, S_->get_time(Amanzi::Tags::NEXT));
+    }
+    ++i;
+  }
+
+  // Custom sub-PK ordering: subsurface first, copy to star, then star PK.
+  // Cannot use MPC<PK>::Initialize() which iterates in declared order.
   sub_pks_[1]->Initialize();
   CopyPrimaryToStar_();
   sub_pks_[0]->Initialize();
+
+  // Initialize TimeAdvancers (sets dt initialized, IC vis/obs, mesh coord backup)
+  for (auto& ta : time_advancers_)
+    if (ta.get()) ta->initialize();
 
   // FIXME -- this order is logically wrong but currently necessary.  The
   // intention is the following initialization process:
@@ -245,11 +262,6 @@ MPCPermafrostSplitFlux::Initialize()
     }
   }
 
-  int i = 0;
-  for (const auto& tag : tags_) {
-    if (subcycling_[i]) S_->GetRecordW("dt", tag.first, name()).set_initialized();
-    ++i;
-  }
 }
 
 

--- a/src/pks/mpc/mpc_subcycled.cc
+++ b/src/pks/mpc/mpc_subcycled.cc
@@ -12,6 +12,7 @@
 */
 
 #include "TimeStepManager.hh"
+#include "time_advancer.hh"
 #include "mpc_subcycled.hh"
 #include "PK_Helpers.hh"
 
@@ -36,26 +37,39 @@ MPCSubcycled::MPCSubcycled(Teuchos::ParameterList& pk_tree,
     Exceptions::amanzi_throw(msg);
   }
   dts_.resize(sub_pks_.size(), -1);
-  tsms_.resize(sub_pks_.size(), Teuchos::null);
+  time_advancers_.resize(sub_pks_.size(), Teuchos::null);
 }
+
 
 void
 MPCSubcycled::parseParameterList()
 {
-  for (int i = 0; i != tsms_.size(); ++i) {
+  for (int i = 0; i != time_advancers_.size(); ++i) {
     if (subcycling_[i]) {
-      Teuchos::ParameterList tsm_plist(std::string("TSM: ") + sub_pks_[i]->name());
-      tsms_[i] = Teuchos::rcp(new Utils::TimeStepManager(tsm_plist));
+      // Locate the TimeAdvancer sublist: "PKNAME time advancer" if present,
+      // else copy from shared "time advancer" if present, else create empty.
+      // Using Teuchos::sublist ensures the sublist is created in plist_ so the
+      // final parameters used are recorded there.
+      std::string pk_ta_key = sub_pks_[i]->name() + " time advancer";
+      if (!plist_->isSublist(pk_ta_key) && plist_->isSublist("time advancer"))
+        plist_->sublist(pk_ta_key) = plist_->sublist("time advancer");
+      auto ta_plist = Teuchos::sublist(plist_, pk_ta_key);
+
+      // create a TSM for this subcycled PK
+      auto tsm = Teuchos::rcp(new Utils::TimeStepManager());
 
       const auto& tag = tags_[i];
       S_->require_time(tag.first);
       S_->require_time(tag.second);
+
+      time_advancers_[i] = Teuchos::rcp(new ATS::TimeAdvancer(
+        ta_plist, S_, sub_pks_[i], tsm,
+        tag.first, tag.second, vo_));
     }
   }
 
   MPC<PK>::parseParameterList();
 
-  // min dt allowed in subcycling
   target_dt_ = plist_->get<double>("subcycling target timestep [s]", -1);
 }
 
@@ -87,26 +101,30 @@ MPCSubcycled::Setup()
   int i = 0;
   for (const auto& tag : tags_) {
     S_->require_cycle(tag.second);
-    if (subcycling_[i]) S_->Require<double>("dt", tag.first, name());
     ++i;
   }
   MPC<PK>::Setup();
+  for (auto& ta : time_advancers_) {
+    if (ta.get()) ta->setup();
+  }
 }
+
 
 void
 MPCSubcycled::Initialize()
-
 {
   int i = 0;
   for (const auto& tag : tags_) {
     if (subcycling_[i]) {
-      S_->GetRecordW("dt", tag.first, name()).set_initialized();
       S_->set_time(tag.first, S_->get_time(Amanzi::Tags::CURRENT));
       S_->set_time(tag.second, S_->get_time(Amanzi::Tags::NEXT));
     }
     ++i;
   }
   MPC<PK>::Initialize();
+  for (auto& ta : time_advancers_) {
+    if (ta.get()) ta->initialize();
+  }
 }
 
 
@@ -155,55 +173,11 @@ MPCSubcycled::set_dt(double dt)
 bool
 MPCSubcycled::AdvanceStep_i_(std::size_t i, double t_old, double t_new, bool reinit)
 {
-  bool fail = false;
   if (subcycling_[i]) {
-    // advance the subcycled, subcycling if needed
-    bool done = false;
-    double t_inner = t_old;
-    double dt_inner = dts_[i];
-    bool fail_inner = false;
-
-    Tag tag_subcycle_current = tags_[i].first;
-    Tag tag_subcycle_next = tags_[i].second;
-
-    tsms_[i]->RegisterTimeEvent(t_new);
-    S_->set_time(tag_subcycle_current, t_old);
-
-    while (!done) {
-      dt_inner = tsms_[i]->TimeStep(t_inner, dt_inner, fail_inner);
-      S_->Assign("dt", tag_subcycle_current, name(), dt_inner);
-      S_->set_time(tag_subcycle_next, t_inner + dt_inner);
-      fail_inner = sub_pks_[i]->AdvanceStep(t_inner, t_inner + dt_inner, false);
-
-      if (vo_->os_OK(Teuchos::VERB_EXTREME))
-        *vo_->os() << "  step failed? " << fail_inner << std::endl;
-
-      if (fail_inner) {
-        sub_pks_[i]->FailStep(t_old, t_new, tag_subcycle_next);
-        dt_inner = sub_pks_[i]->get_dt();
-
-        if (vo_->os_OK(Teuchos::VERB_EXTREME))
-          *vo_->os() << "  failed, new timestep is " << dt_inner << std::endl;
-
-      } else {
-        sub_pks_[i]->CommitStep(t_inner, t_inner + dt_inner, tag_subcycle_next);
-        t_inner += dt_inner;
-        if (std::abs(t_new - t_inner) < 1.e-10) done = true;
-
-        S_->set_time(tag_subcycle_current, S_->get_time(tag_subcycle_next));
-        S_->advance_cycle(tag_subcycle_next);
-
-        dt_inner = sub_pks_[i]->get_dt();
-        if (vo_->os_OK(Teuchos::VERB_EXTREME))
-          *vo_->os() << "  success, new timestep is " << dt_inner << std::endl;
-      }
-    }
-
+    return time_advancers_[i]->advance(t_old, t_new);
   } else {
-    // advance the standard PK using the full step size
-    fail = sub_pks_[i]->AdvanceStep(t_old, t_new, reinit);
+    return sub_pks_[i]->AdvanceStep(t_old, t_new, reinit);
   }
-  return fail;
 }
 
 

--- a/src/pks/mpc/mpc_subcycled.hh
+++ b/src/pks/mpc/mpc_subcycled.hh
@@ -22,6 +22,21 @@ A generic MPC that weakly couples N PKs, potentially subcycling any of them.
      independently without synchronization.  This is required if all sub-PKs are
      being subcycled.
 
+   Each subcycled PK's ``TimeAdvancer`` is configured from a sublist.  The
+   lookup order is:
+
+   1. ``"PKNAME time advancer"`` sublist — per-PK configuration (vis, obs, etc.)
+   2. ``"time advancer"`` sublist — shared fallback for all subcycled PKs
+   3. Empty list — no vis/obs for subcycled PKs
+
+   Example::
+
+     <ParameterList name="subcycling MPC">
+       <ParameterList name="subsurface flow time advancer">
+         <ParameterList name="visualization"> ... </ParameterList>
+       </ParameterList>
+     </ParameterList>
+
    INCLUDES:
 
    - ``[mpc-spec]`` *Is a* :ref:`MPC`.
@@ -33,6 +48,10 @@ A generic MPC that weakly couples N PKs, potentially subcycling any of them.
 
 #include "PK.hh"
 #include "mpc.hh"
+
+namespace ATS {
+class TimeAdvancer;
+} // namespace ATS
 
 namespace Amanzi {
 
@@ -66,7 +85,7 @@ class MPCSubcycled : public MPC<PK> {
   double dt_, target_dt_;
   std::vector<double> dts_;
   std::vector<std::pair<Tag, Tag>> tags_;
-  std::vector<Teuchos::RCP<Utils::TimeStepManager>> tsms_;
+  std::vector<Teuchos::RCP<ATS::TimeAdvancer>> time_advancers_;
 
  private:
   // factory registration

--- a/src/pks/mpc/mpc_weak_subdomain.cc
+++ b/src/pks/mpc/mpc_weak_subdomain.cc
@@ -23,6 +23,8 @@ input spec.
 */
 
 
+#include "TimeStepManager.hh"
+#include "time_advancer.hh"
 #include "mpc_weak_subdomain.hh"
 
 
@@ -48,6 +50,29 @@ MPCWeakSubdomain::parseParameterList()
 
   if (internal_subcycling_) {
     internal_subcycling_target_dt_ = plist_->template get<double>("subcycling target timestep [s]");
+
+    const auto& ds = S_->GetDomainSet(ds_name_);
+    int i = 0;
+    for (const auto& subdomain : *ds) {
+      // Locate the TimeAdvancer sublist: "PKNAME time advancer" if present,
+      // else copy from shared "time advancer" if present, else create empty.
+      // Using Teuchos::sublist ensures the sublist is created in plist_ so the
+      // final parameters used are recorded there.
+      std::string pk_ta_key = sub_pks_[i]->name() + " time advancer";
+      if (!plist_->isSublist(pk_ta_key) && plist_->isSublist("time advancer"))
+        plist_->sublist(pk_ta_key) = plist_->sublist("time advancer");
+      auto ta_plist = Teuchos::sublist(plist_, pk_ta_key);
+
+      Tag tag_current = get_ds_tag_current_(subdomain);
+      Tag tag_next = get_ds_tag_next_(subdomain);
+      S_->require_time(tag_current);
+      S_->require_time(tag_next);
+
+      auto tsm = Teuchos::rcp(new Utils::TimeStepManager());
+      time_advancers_.emplace_back(Teuchos::rcp(new ATS::TimeAdvancer(
+        ta_plist, S_, sub_pks_[i], tsm, tag_current, tag_next, vo_)));
+      ++i;
+    }
   }
 };
 
@@ -134,33 +159,16 @@ MPCWeakSubdomain::get_ds_tag_current_(const std::string& subdomain)
 void
 MPCWeakSubdomain::Setup()
 {
-  if (internal_subcycling_) {
-    const auto& ds = S_->GetDomainSet(ds_name_);
-    for (const auto& subdomain : *ds) {
-      Tag tag_subcycle_current = get_ds_tag_current_(subdomain);
-      Tag tag_subcycle_next = get_ds_tag_next_(subdomain);
-
-      S_->require_time(tag_subcycle_current);
-      S_->require_time(tag_subcycle_next);
-      S_->require_cycle(tag_subcycle_next);
-      S_->Require<double>("dt", tag_subcycle_next, name());
-    }
-  }
   MPC<PK>::Setup();
+  for (auto& ta : time_advancers_) ta->setup();
 }
 
 
 void
 MPCWeakSubdomain::Initialize()
 {
-  if (internal_subcycling_) {
-    const auto& ds = S_->GetDomainSet(ds_name_);
-    for (const auto& subdomain : *ds) {
-      Tag tag_subcycle_next = get_ds_tag_next_(subdomain);
-      S_->GetRecordW("dt", tag_subcycle_next, name()).set_initialized();
-    }
-  }
   MPC<PK>::Initialize();
+  for (auto& ta : time_advancers_) ta->initialize();
 }
 
 
@@ -194,65 +202,24 @@ MPCWeakSubdomain::AdvanceStep_Standard_(double t_old, double t_new, bool reinit)
 
 
 //-------------------------------------------------------------------------------------
-// Advance the timestep through subcyling
+// Advance the timestep through subcycling
 //-------------------------------------------------------------------------------------
 bool
 MPCWeakSubdomain::AdvanceStep_InternalSubcycling_(double t_old, double t_new, bool reinit)
 {
   Teuchos::OSTab tab = vo_->getOSTab();
-  bool fail = false;
   if (vo_->os_OK(Teuchos::VERB_EXTREME))
     *vo_->os() << "Beginning subcycled timestepping." << std::endl;
 
-  const auto& ds = *S_->GetDomainSet(ds_name_);
-  int my_pid = solution_->Comm()->MyPID();
-
-  int i = 0;
+  // Each subdomain PK runs on a potentially different sub-communicator, so
+  // TimestepCrash is non-collective.  Catch per-subdomain and broadcast.
   int n_throw = 0;
   std::string throw_msg;
-  for (const auto& subdomain : ds) {
-    double dt_inner = -1;
-    double t_inner = t_old;
-    try { // must catch non-collective throws for TimestepCrash
+  for (int i = 0; i != (int)time_advancers_.size(); ++i) {
+    try {
       if (vo_->os_OK(Teuchos::VERB_EXTREME))
-        *vo_->os() << "Beginning subcyling on pk \"" << sub_pks_[i]->name() << "\"" << std::endl;
-
-      bool done = false;
-      Tag tag_subcycle_current = get_ds_tag_current_(subdomain);
-      Tag tag_subcycle_next = get_ds_tag_next_(subdomain);
-
-      S_->set_time(tag_subcycle_current, t_old);
-      while (!done) {
-        dt_inner = std::min(sub_pks_[i]->get_dt(), t_new - t_inner);
-        S_->Assign("dt", tag_subcycle_next, name(), dt_inner);
-        S_->set_time(tag_subcycle_next, t_inner + dt_inner);
-        bool fail_inner = sub_pks_[i]->AdvanceStep(t_inner, t_inner + dt_inner, false);
-        if (vo_->os_OK(Teuchos::VERB_EXTREME))
-          *vo_->os() << "  step failed? " << fail_inner << std::endl;
-
-        if (fail_inner) {
-          sub_pks_[i]->FailStep(t_old, t_new, tag_subcycle_next);
-
-          dt_inner = sub_pks_[i]->get_dt();
-          S_->set_time(tag_subcycle_next, S_->get_time(tag_subcycle_current));
-
-          if (vo_->os_OK(Teuchos::VERB_EXTREME))
-            *vo_->os() << "  failed, new timestep is " << dt_inner << std::endl;
-
-        } else {
-          sub_pks_[i]->CommitStep(t_inner, t_inner + dt_inner, tag_subcycle_next);
-          t_inner += dt_inner;
-          if (std::abs(t_new - t_inner) < 1.e-10) done = true;
-
-          S_->set_time(tag_subcycle_current, S_->get_time(tag_subcycle_next));
-          S_->advance_cycle(tag_subcycle_next);
-
-          dt_inner = sub_pks_[i]->get_dt();
-          if (vo_->os_OK(Teuchos::VERB_EXTREME))
-            *vo_->os() << "  success, new timestep is " << dt_inner << std::endl;
-        }
-      }
-      i++;
+        *vo_->os() << "Beginning subcycling on pk \"" << sub_pks_[i]->name() << "\"" << std::endl;
+      time_advancers_[i]->advance(t_old, t_new);
     } catch (Errors::TimestepCrash& e) {
       n_throw++;
       throw_msg = e.what();
@@ -260,11 +227,9 @@ MPCWeakSubdomain::AdvanceStep_InternalSubcycling_(double t_old, double t_new, bo
     }
   }
 
-  // check for any other ranks throwing and, if so, throw ourselves so that all procs throw
   int n_throw_g = 0;
   comm_->SumAll(&n_throw, &n_throw_g, 1);
   if (n_throw > 0) {
-    // inject more information into the crash message
     Errors::TimestepCrash msg;
     msg << throw_msg << "  on rank " << comm_->MyPID() << " of " << comm_->NumProc();
     Exceptions::amanzi_throw(msg);

--- a/src/pks/mpc/mpc_weak_subdomain.hh
+++ b/src/pks/mpc/mpc_weak_subdomain.hh
@@ -27,6 +27,13 @@ set.  It may also subcycle all or none of its child PKs.
    * `"subcycling target timestep [s]`" ``[double]`` timestep over which to
      syncronize the sub PKs.
 
+   Each subcycled PK's ``TimeAdvancer`` is configured from a sublist using the
+   same lookup order as :ref:`MPCSubcycled <pk-subcycling-mpc-spec>`:
+
+   1. ``"PKNAME time advancer"`` sublist — per-PK configuration (vis, obs, etc.)
+   2. ``"time advancer"`` sublist — shared configuration for all subcycled PKs
+   3. Empty list — no vis/obs for subcycled PKs
+
    END
 
    INCLUDES
@@ -39,6 +46,10 @@ set.  It may also subcycle all or none of its child PKs.
 
 #pragma once
 #include "mpc.hh"
+
+namespace ATS {
+class TimeAdvancer;
+} // namespace ATS
 
 namespace Amanzi {
 
@@ -78,6 +89,7 @@ class MPCWeakSubdomain : public MPC<PK> {
   double internal_subcycling_target_dt_;
   double cycle_dt_;
   Key ds_name_;
+  std::vector<Teuchos::RCP<ATS::TimeAdvancer>> time_advancers_;
 
  private:
   // factory registration

--- a/src/pks/time_advancer.cc
+++ b/src/pks/time_advancer.cc
@@ -1,0 +1,312 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon
+*/
+
+#include <iomanip>
+
+#include "errors.hh"
+#include "Teuchos_TimeMonitor.hpp"
+
+#include "CompositeVector.hh"
+#include "TimeStepManager.hh"
+#include "Visualization.hh"
+#include "VisualizationDomainSet.hh"
+#include "Checkpoint.hh"
+#include "UnstructuredObservations.hh"
+#include "State.hh"
+#include "PK.hh"
+#include "PK_Helpers.hh"
+#include "IO.hh"
+
+#include "time_advancer.hh"
+
+namespace ATS {
+
+TimeAdvancer::TimeAdvancer(const Teuchos::RCP<Teuchos::ParameterList>& plist,
+                           const Teuchos::RCP<Amanzi::State>& S,
+                           const Teuchos::RCP<Amanzi::PK>& pk,
+                           const Teuchos::RCP<Amanzi::Utils::TimeStepManager>& tsm,
+                           const Amanzi::Tag& tag_current,
+                           const Amanzi::Tag& tag_next,
+                           const Teuchos::RCP<Amanzi::VerboseObject>& vo,
+                           const Teuchos::RCP<Teuchos::Time>& wallclock_timer)
+  : plist_(plist),
+    vo_(vo),
+    S_(S),
+    pk_(pk),
+    tsm_(tsm),
+    tag_current_(tag_current),
+    tag_next_(tag_next),
+    wallclock_timer_(wallclock_timer),
+    max_dt_(plist->get<double>("max timestep size [s]", 1.0e99)),
+    min_dt_(plist->get<double>("min timestep size [s]", 1.0e-12)),
+    cycle1_(plist->get<int>("end cycle", -1)),
+    duration_(plist->get<double>("wallclock duration [hrs]", -1.0)),
+    subcycled_ts_(plist->get<bool>("subcycled timestep", false))
+{
+  // construct checkpoint — always created so finalize() can write a final checkpoint;
+  // only register with TSM for periodic checkpoints if the sublist is present.
+  checkpoint_obj_ = Teuchos::rcp(
+    new Amanzi::Checkpoint(plist_->sublist("checkpoint"), *S_));
+  if (plist_->isSublist("checkpoint"))
+    checkpoint_obj_->RegisterWithTimeStepManager(*tsm_);
+
+  // construct observations
+  if (plist_->isSublist("observations")) {
+    auto& obs_list = plist_->sublist("observations");
+    for (auto& entry : obs_list) {
+      if (obs_list.isSublist(entry.first)) {
+        observations_.emplace_back(
+          Teuchos::rcp(new Amanzi::UnstructuredObservations(obs_list.sublist(entry.first))));
+        observations_.back()->RegisterWithTimeStepManager(*tsm_);
+      } else {
+        Errors::Message msg("\"observations\" list must only include sublists.");
+        Exceptions::amanzi_throw(msg);
+      }
+    }
+  }
+
+  // construct visualization
+  if (plist_->isSublist("visualization")) {
+    auto vis_list = Teuchos::sublist(plist_, "visualization");
+    for (auto& entry : *vis_list) {
+      std::string domain_name = entry.first;
+      if (S_->HasMesh(domain_name)) {
+        auto mesh_p = S_->GetMesh(domain_name);
+        auto sublist_p = Teuchos::sublist(vis_list, domain_name);
+        if (!sublist_p->isParameter("file name base")) {
+          if (domain_name.empty() || domain_name == "domain") {
+            sublist_p->set<std::string>("file name base", std::string("ats_vis"));
+          } else {
+            sublist_p->set<std::string>("file name base", std::string("ats_vis_") + domain_name);
+          }
+        }
+        if (S_->HasMesh(domain_name + "_3d") && sublist_p->get<bool>("visualize on 3D mesh", true))
+          mesh_p = S_->GetMesh(domain_name + "_3d");
+        auto vis = Teuchos::rcp(new Amanzi::Visualization(*sublist_p));
+        vis->set_name(domain_name);
+        vis->set_mesh(mesh_p);
+        vis->CreateFiles(false);
+        visualization_.push_back(vis);
+      } else if (Amanzi::Keys::isDomainSet(domain_name)) {
+        const auto& dset = S_->GetDomainSet(Amanzi::Keys::getDomainSetName(domain_name));
+        auto sublist_p = Teuchos::sublist(vis_list, domain_name);
+        if (sublist_p->get("visualize individually", false)) {
+          for (const auto& subdomain : *dset) {
+            Teuchos::ParameterList sublist = vis_list->sublist(subdomain);
+            sublist.set<std::string>("file name base", std::string("ats_vis_") + subdomain);
+            auto vis = Teuchos::rcp(new Amanzi::Visualization(sublist));
+            vis->set_name(subdomain);
+            vis->set_mesh(S_->GetMesh(subdomain));
+            vis->CreateFiles(false);
+            visualization_.push_back(vis);
+          }
+        } else {
+          auto domain_name_base = Amanzi::Keys::getDomainSetName(domain_name);
+          if (!sublist_p->isParameter("file name base"))
+            sublist_p->set("file name base", std::string("ats_vis_") + domain_name_base);
+          auto vis = Teuchos::rcp(new Amanzi::VisualizationDomainSet(*sublist_p));
+          vis->set_name(domain_name_base);
+          vis->set_domain_set(dset);
+          vis->set_mesh(dset->getReferencingParent());
+          vis->CreateFiles(false);
+          visualization_.push_back(vis);
+        }
+      }
+      for (const auto& vis : visualization_) vis->RegisterWithTimeStepManager(*tsm_);
+    }
+  }
+
+  // construct failed visualization (no TSM registration needed)
+  if (plist_->isSublist("visualization failed")) {
+    auto vis_list = Teuchos::sublist(plist_, "visualization failed");
+    for (auto& entry : *vis_list) {
+      std::string domain_name = entry.first;
+      if (S_->HasMesh(domain_name)) {
+        auto mesh_p = S_->GetMesh(domain_name);
+        auto sublist_p = Teuchos::sublist(vis_list, domain_name);
+        if (!sublist_p->isParameter("file name base"))
+          sublist_p->set<std::string>("file name base", std::string("ats_vis_failed_") + domain_name);
+        auto vis = Teuchos::rcp(new Amanzi::Visualization(*sublist_p));
+        vis->set_name(domain_name);
+        vis->set_mesh(mesh_p);
+        vis->CreateFiles(false);
+        failed_visualization_.push_back(vis);
+      }
+    }
+  }
+}
+
+
+void
+TimeAdvancer::setup()
+{
+  S_->require_cycle(tag_next_);
+  S_->Require<double>("dt", tag_next_, "dt");
+
+  for (auto& obs : observations_) obs->Setup(S_.ptr());
+}
+
+
+void
+TimeAdvancer::initialize()
+{
+  // initialize dt if not already done (e.g. by a restart)
+  if (!S_->GetRecord("dt", tag_next_).initialized())
+    S_->GetRecordW("dt", tag_next_, "dt").set_initialized();
+
+  // dump initial conditions
+  visualize_();
+  observe_();
+  checkpoint_();
+}
+
+
+void
+TimeAdvancer::finalize(bool checkpoint)
+{
+  if (checkpoint) checkpoint_obj_->Write(*S_, Amanzi::Checkpoint::WriteType::FINAL);
+  for (const auto& obs : observations_) obs->Flush();
+}
+
+
+bool
+TimeAdvancer::advance(double t_start, double t_end)
+{
+  // register end time as a required TSM event
+  tsm_->RegisterTimeEvent(t_end);
+  S_->set_time(tag_current_, t_start);
+  S_->set_time(tag_next_, t_start);
+
+  double dt = pk_->get_dt();
+  if (dt > max_dt_) dt = max_dt_;
+  bool fail = false;
+
+  while (true) {
+    double t_now = S_->get_time(tag_current_);
+
+    // done?
+    if (std::abs(t_end - t_now) < 1.e-10 * std::abs(t_end + 1.)) break;
+    if (extraDoneCheck_(t_now, S_->get_cycle())) break;
+    if (dt <= 0.) break;
+
+    // constrain dt via TSM, then clamp
+    dt = tsm_->TimeStep(t_now, dt, fail);
+    if (dt < min_dt_) {
+      Errors::Message msg("TimeAdvancer: timestep too small");
+      Exceptions::amanzi_throw(msg);
+    }
+    double dt_pk = dt;
+    if (subcycled_ts_) {
+      double raw = pk_->get_dt();
+      dt = std::min(dt, raw);
+    }
+
+    if (vo_->os_OK(Teuchos::VERB_LOW)) {
+      *vo_->os() << "================================================================================"
+                 << std::endl << std::endl
+                 << "Cycle = " << S_->get_cycle(tag_next_)
+                 << ",  Time [days] = " << std::setprecision(16)
+                 << t_now / (60 * 60 * 24)
+                 << ",  dt [days] = " << std::setprecision(16)
+                 << dt / (60 * 60 * 24) << std::endl
+                 << "--------------------------------------------------------------------------------"
+                 << std::endl;
+    }
+
+    S_->Assign("dt", tag_next_, "dt", dt);
+    S_->set_time(tag_next_, t_now + dt);
+
+    fail = pk_->AdvanceStep(t_now, t_now + dt, false);
+
+    WriteStateStatistics(*S_, *vo_, Teuchos::VERB_EXTREME);
+
+    if (fail) {
+      for (const auto& vis : failed_visualization_) WriteVis(*vis, *S_);
+      pk_->FailStep(t_now, t_now + dt, tag_next_);
+      S_->set_time(tag_next_, t_now);
+      onFail_(t_now, t_now + dt);
+      dt = pk_->get_dt();
+    } else {
+      pk_->CommitStep(t_now, t_now + dt, tag_next_);
+      S_->set_time(tag_current_, t_now + dt);
+      S_->advance_cycle(tag_next_);
+      onSuccess_(t_now, t_now + dt);
+      dt = pk_->get_dt();
+    }
+    if (dt > max_dt_) dt = max_dt_;
+
+    WriteStateStatistics(*S_, *vo_, Teuchos::VERB_EXTREME);
+  }
+  return false;
+}
+
+
+void
+TimeAdvancer::onSuccess_(double t_old, double t_new)
+{
+  visualize_();
+  observe_();
+  checkpoint_();
+}
+
+
+void
+TimeAdvancer::onFail_(double t_old, double t_new)
+{
+  // Deformable mesh coordinate recovery on failure is handled by the
+  // VolumetricDeformation PK in its FailStep() method.
+}
+
+
+bool
+TimeAdvancer::extraDoneCheck_(double t, int cycle) const
+{
+  if (cycle1_ >= 0 && cycle > cycle1_) return true;
+  if (duration_ > 0. && wallclock_timer_ != Teuchos::null) {
+    if (wallclock_timer_->totalElapsedTime(true) >= duration_ * 3600.) return true;
+  }
+  return false;
+}
+
+
+bool
+TimeAdvancer::visualize_(bool force)
+{
+  bool dump = force;
+  int cycle = S_->get_cycle();
+  double time = S_->get_time();
+  if (!dump) {
+    for (const auto& vis : visualization_) dump |= vis->DumpRequested(cycle, time);
+  }
+  if (dump) pk_->CalculateDiagnostics(tag_next_);
+  for (const auto& vis : visualization_) {
+    if (force || vis->DumpRequested(cycle, time)) WriteVis(*vis, *S_);
+  }
+  return dump;
+}
+
+
+void
+TimeAdvancer::observe_()
+{
+  for (const auto& obs : observations_) obs->MakeObservations(S_.ptr());
+}
+
+
+bool
+TimeAdvancer::checkpoint_(bool force)
+{
+  int cycle = S_->get_cycle();
+  double time = S_->get_time();
+  bool dump = force || checkpoint_obj_->DumpRequested(cycle, time);
+  if (dump) checkpoint_obj_->Write(*S_);
+  return dump;
+}
+
+} // namespace ATS

--- a/src/pks/time_advancer.cc
+++ b/src/pks/time_advancer.cc
@@ -232,6 +232,7 @@ TimeAdvancer::advance(double t_start, double t_end)
     }
 
     if (vo_->os_OK(Teuchos::VERB_LOW)) {
+      Teuchos::OSTab tab = vo_->getOSTab();
       *vo_->os() << "================================================================================"
                  << std::endl << std::endl
                  << "Cycle = " << S_->get_cycle(tag_next_)

--- a/src/pks/time_advancer.cc
+++ b/src/pks/time_advancer.cc
@@ -24,6 +24,7 @@
 #include "IO.hh"
 
 #include "time_advancer.hh"
+#include "EvaluatorTimeAccumulated.hh"
 
 namespace ATS {
 
@@ -150,6 +151,13 @@ TimeAdvancer::setup()
   S_->Require<double>("dt", tag_next_, "dt");
 
   for (auto& obs : observations_) obs->Setup(S_.ptr());
+
+  // parse "time accumulators" list: each entry is "key@tag"
+  if (plist_->isParameter("time accumulators")) {
+    auto keytag_strs = plist_->get<Teuchos::Array<std::string>>("time accumulators");
+    for (const auto& s : keytag_strs)
+      accumulator_keytags_.push_back(Amanzi::Keys::splitKeyTag(s));
+  }
 }
 
 
@@ -159,6 +167,19 @@ TimeAdvancer::initialize()
   // initialize dt if not already done (e.g. by a restart)
   if (!S_->GetRecord("dt", tag_next_).initialized())
     S_->GetRecordW("dt", tag_next_, "dt").set_initialized();
+
+  // resolve time accumulator evaluators now that State is fully set up
+  for (const auto& kt : accumulator_keytags_) {
+    auto* eval = dynamic_cast<Amanzi::Relations::EvaluatorTimeAccumulated*>(
+      &S_->GetEvaluator(kt.first, kt.second));
+    if (!eval) {
+      Errors::Message msg;
+      msg << "TimeAdvancer: \"time accumulators\" entry \"" << kt.first << "@" << kt.second.get()
+          << "\" is not an EvaluatorTimeAccumulated";
+      Exceptions::amanzi_throw(msg);
+    }
+    accumulators_.push_back(eval);
+  }
 
   // dump initial conditions
   visualize_();
@@ -182,6 +203,9 @@ TimeAdvancer::advance(double t_start, double t_end)
   tsm_->RegisterTimeEvent(t_end);
   S_->set_time(tag_current_, t_start);
   S_->set_time(tag_next_, t_start);
+
+  // reset all time accumulators at the start of each outer timestep
+  for (auto* acc : accumulators_) acc->Reset(*S_);
 
   double dt = pk_->get_dt();
   if (dt > max_dt_) dt = max_dt_;
@@ -230,13 +254,13 @@ TimeAdvancer::advance(double t_start, double t_end)
       for (const auto& vis : failed_visualization_) WriteVis(*vis, *S_);
       pk_->FailStep(t_now, t_now + dt, tag_next_);
       S_->set_time(tag_next_, t_now);
-      onFail_(t_now, t_now + dt);
+      FailStep_(t_now, t_now + dt);
       dt = pk_->get_dt();
     } else {
       pk_->CommitStep(t_now, t_now + dt, tag_next_);
       S_->set_time(tag_current_, t_now + dt);
       S_->advance_cycle(tag_next_);
-      onSuccess_(t_now, t_now + dt);
+      CommitStep_(t_now, t_now + dt);
       dt = pk_->get_dt();
     }
     if (dt > max_dt_) dt = max_dt_;
@@ -248,8 +272,9 @@ TimeAdvancer::advance(double t_start, double t_end)
 
 
 void
-TimeAdvancer::onSuccess_(double t_old, double t_new)
+TimeAdvancer::CommitStep_(double t_old, double t_new)
 {
+  for (auto* acc : accumulators_) acc->Update(*S_, "time_advancer");
   visualize_();
   observe_();
   checkpoint_();
@@ -257,7 +282,7 @@ TimeAdvancer::onSuccess_(double t_old, double t_new)
 
 
 void
-TimeAdvancer::onFail_(double t_old, double t_new)
+TimeAdvancer::FailStep_(double t_old, double t_new)
 {
   // Deformable mesh coordinate recovery on failure is handled by the
   // VolumetricDeformation PK in its FailStep() method.

--- a/src/pks/time_advancer.hh
+++ b/src/pks/time_advancer.hh
@@ -1,0 +1,130 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon
+*/
+
+//! Drives a PK through a sequence of timesteps from t_start to t_end.
+/*!
+
+TimeAdvancer owns the while(!done) timestep loop, including vis, observations,
+checkpointing, and deformable mesh recovery on failed steps.  It is used by
+standalone drivers (ATSDriver), externally-coupled drivers (ELM_ATSDriver), and
+subcycled MPCs (MPCSubcycled).
+
+The single public entry point is:
+
+   bool advance(double t_start, double t_end);
+
+which drives the PK from t_start to t_end, subcycling internally as needed.
+
+.. _time-advancer-spec:
+.. admonition:: time-advancer-spec
+
+   * `"end cycle`" ``[int]`` **-1** If >= 0, stop when cycle reaches this value.
+   * `"wallclock duration [hrs]`" ``[double]`` **-1** If > 0, stop after this many
+     wallclock hours.
+   * `"max timestep size [s]`" ``[double]`` **1e99** Cap on dt.
+   * `"min timestep size [s]`" ``[double]`` **1e-12** If dt falls below this, throw.
+   * `"subcycled timestep`" ``[bool]`` **false** If true, limit dt to the PK's
+     suggested dt even after TSM expansion.
+   * `"checkpoint`" ``[checkpoint-spec]`` **optional** Checkpoint output spec.
+   * `"observations`" ``[observation-spec-list]`` **optional** Observation specs.
+   * `"visualization`" ``[visualization-spec-list]`` **optional** Vis specs.
+   * `"visualization failed`" ``[visualization-spec-list]`` **optional** Vis on
+     failed steps.
+
+*/
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_Time.hpp"
+
+#include "Key.hh"
+#include "Tag.hh"
+#include "VerboseObject.hh"
+
+namespace Amanzi {
+class PK;
+class State;
+class Visualization;
+class Checkpoint;
+class UnstructuredObservations;
+namespace Utils {
+class TimeStepManager;
+} // namespace Utils
+} // namespace Amanzi
+
+namespace ATS {
+
+class TimeAdvancer {
+ public:
+  TimeAdvancer(const Teuchos::RCP<Teuchos::ParameterList>& plist,
+               const Teuchos::RCP<Amanzi::State>& S,
+               const Teuchos::RCP<Amanzi::PK>& pk,
+               const Teuchos::RCP<Amanzi::Utils::TimeStepManager>& tsm,
+               const Amanzi::Tag& tag_current,
+               const Amanzi::Tag& tag_next,
+               const Teuchos::RCP<Amanzi::VerboseObject>& vo,
+               const Teuchos::RCP<Teuchos::Time>& wallclock_timer = Teuchos::null);
+
+  // Must be called during Driver::setup(), before State::Setup(), to allow
+  // observations to require fields on State.
+  void setup();
+
+  // Must be called during Driver::initialize(), after State is fully
+  // initialized, to dump IC output.
+  void initialize();
+
+  // Must be called during Driver::finalize() to flush observations and
+  // optionally write a final checkpoint.
+  void finalize(bool checkpoint = true);
+
+  // Advance the PK from t_start to t_end.  Returns true on unrecoverable failure.
+  bool advance(double t_start, double t_end);
+
+ protected:
+  // Hooks called after each inner step — override for custom behavior.
+  // Default onSuccess_() calls vis, observations, and checkpoint.
+  // Default onFail_() calls failed visualization.
+  virtual void onSuccess_(double t_old, double t_new);
+  virtual void onFail_(double t_old, double t_new);
+
+ private:
+  // True when the loop should stop (besides reaching t_end).
+  bool extraDoneCheck_(double t, int cycle) const;
+
+  // vis/obs/checkpoint helpers
+  bool visualize_(bool force = false);
+  void observe_();
+  bool checkpoint_(bool force = false);
+
+  Teuchos::RCP<Teuchos::ParameterList> plist_;
+  Teuchos::RCP<Amanzi::VerboseObject> vo_;
+  Teuchos::RCP<Amanzi::State> S_;
+  Teuchos::RCP<Amanzi::PK> pk_;
+  Teuchos::RCP<Amanzi::Utils::TimeStepManager> tsm_;
+  Amanzi::Tag tag_current_, tag_next_;
+  Teuchos::RCP<Teuchos::Time> wallclock_timer_;
+
+  double max_dt_, min_dt_;
+  int cycle1_;
+  double duration_;
+  bool subcycled_ts_;
+
+  std::vector<Teuchos::RCP<Amanzi::Visualization>> visualization_;
+  std::vector<Teuchos::RCP<Amanzi::Visualization>> failed_visualization_;
+  Teuchos::RCP<Amanzi::Checkpoint> checkpoint_obj_;
+  std::vector<Teuchos::RCP<Amanzi::UnstructuredObservations>> observations_;
+};
+
+} // namespace ATS

--- a/src/pks/time_advancer.hh
+++ b/src/pks/time_advancer.hh
@@ -64,6 +64,12 @@ class TimeStepManager;
 } // namespace Utils
 } // namespace Amanzi
 
+namespace Amanzi {
+namespace Relations {
+class EvaluatorTimeAccumulated;
+} // namespace Relations
+} // namespace Amanzi
+
 namespace ATS {
 
 class TimeAdvancer {
@@ -94,10 +100,10 @@ class TimeAdvancer {
 
  protected:
   // Hooks called after each inner step — override for custom behavior.
-  // Default onSuccess_() calls vis, observations, and checkpoint.
-  // Default onFail_() calls failed visualization.
-  virtual void onSuccess_(double t_old, double t_new);
-  virtual void onFail_(double t_old, double t_new);
+  // Default CommitStep_() calls vis, observations, and checkpoint.
+  // Default FailStep_() calls failed visualization.
+  virtual void CommitStep_(double t_old, double t_new);
+  virtual void FailStep_(double t_old, double t_new);
 
  private:
   // True when the loop should stop (besides reaching t_end).
@@ -125,6 +131,10 @@ class TimeAdvancer {
   std::vector<Teuchos::RCP<Amanzi::Visualization>> failed_visualization_;
   Teuchos::RCP<Amanzi::Checkpoint> checkpoint_obj_;
   std::vector<Teuchos::RCP<Amanzi::UnstructuredObservations>> observations_;
+
+  // time accumulation evaluators driven each inner step
+  std::vector<Amanzi::KeyTag> accumulator_keytags_;
+  std::vector<Amanzi::Relations::EvaluatorTimeAccumulated*> accumulators_;
 };
 
 } // namespace ATS

--- a/tools/utils/plot_timestep_history.py
+++ b/tools/utils/plot_timestep_history.py
@@ -31,7 +31,7 @@ def parse_logfile(fid, wallclock=False):
     # find number of "cycles"
     total_cycles = 0
     for i, line in enumerate(fid):
-        if "Cycle =" in line:
+        if "Cycle =" in line and "ELM Cycle" not in line:
             # try:
                 cyc, time, dt = parse_line(line)
             # except:


### PR DESCRIPTION
- Adds support for sub cycling ATS in an ELM step
- makes sure accepted log file gets used, so output is written to ats.log.TIMESTAMP to follow ELM pattern.